### PR TITLE
Add growth trends, trust filters, and uptime checks

### DIFF
--- a/.github/workflows/uptime-checks.yml
+++ b/.github/workflows/uptime-checks.yml
@@ -1,0 +1,44 @@
+name: Uptime Checks
+
+on:
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+
+jobs:
+  uptime:
+    name: Public + Cron Health
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      APP_BASE_URL: ${{ secrets.APP_BASE_URL || 'https://sideflip.vercel.app' }}
+      CRON_SECRET: ${{ secrets.CRON_SECRET }}
+    steps:
+      - name: Check public routes
+        run: |
+          set -euo pipefail
+          for path in / /browse /beta; do
+            code=$(curl -sS -o /dev/null -w "%{http_code}" "${APP_BASE_URL}${path}")
+            echo "${path} -> ${code}"
+            if [ "${code}" -ne 200 ]; then
+              echo "Expected 200 for ${path}, got ${code}"
+              exit 1
+            fi
+          done
+
+      - name: Check cron routes with auth
+        if: ${{ env.CRON_SECRET != '' }}
+        run: |
+          set -euo pipefail
+          for path in /api/cron/admin/daily-payout-summary /api/cron/admin/payout-reconciliation; do
+            code=$(curl -sS -o /dev/null -w "%{http_code}" -H "Authorization: Bearer ${CRON_SECRET}" "${APP_BASE_URL}${path}")
+            echo "${path} -> ${code}"
+            if [ "${code}" -ne 200 ]; then
+              echo "Expected 200 for ${path}, got ${code}"
+              exit 1
+            fi
+          done
+
+      - name: Warn when CRON_SECRET is missing
+        if: ${{ env.CRON_SECRET == '' }}
+        run: echo "::warning::Skipping cron endpoint checks because CRON_SECRET is missing in GitHub repo secrets."

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ npm test
 npm run build
 ```
 
+## GitHub Automation
+
+- `CI` workflow runs on every push/PR to `main`.
+- `Uptime Checks` workflow runs every 30 minutes and checks:
+  - `/`
+  - `/browse`
+  - `/beta`
+  - `/api/cron/admin/daily-payout-summary` (when `CRON_SECRET` secret is set)
+  - `/api/cron/admin/payout-reconciliation` (when `CRON_SECRET` secret is set)
+
+Recommended GitHub repo secrets:
+- `APP_BASE_URL` (optional, defaults to `https://sideflip.vercel.app`)
+- `CRON_SECRET` (required for authenticated cron health checks)
+
 ## E2E Smoke Tests (Playwright)
 
 ```bash

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -276,36 +276,53 @@ export default async function AdminPage({ searchParams }: Props) {
 
       <section className="rounded-lg border border-zinc-800 bg-zinc-900">
         <div className="border-b border-zinc-800 px-4 py-3">
-          <h2 className="text-base font-semibold text-zinc-100">Growth Funnel ({funnel.lookbackDays}d)</h2>
+          <h2 className="text-base font-semibold text-zinc-100">
+            Growth Funnel ({funnel.shortWindowDays}d vs {funnel.longWindowDays}d)
+          </h2>
           <p className="text-xs text-zinc-500">
-            Conversion checkpoints from real product actions. Use this to spot bottlenecks quickly.
+            Trend view for key conversion checkpoints plus demand split by region/currency.
           </p>
         </div>
-        <div className="grid grid-cols-1 gap-4 p-4 xl:grid-cols-2">
+        <div className="grid grid-cols-1 gap-4 p-4 xl:grid-cols-3">
           <div className="rounded-md border border-zinc-800 bg-zinc-950/60 p-3">
             <p className="text-xs uppercase tracking-wide text-zinc-500">Marketplace Funnel</p>
             <div className="mt-3 grid grid-cols-1 gap-2 text-sm">
               <div className="rounded border border-zinc-800 px-3 py-2">
-                <p className="text-zinc-200">Listings Created: {funnel.marketplace.listingsCreated}</p>
-              </div>
-              <div className="rounded border border-zinc-800 px-3 py-2">
-                <p className="text-zinc-200">Ownership Verified: {funnel.marketplace.listingsVerified}</p>
-                <p className="text-xs text-zinc-500">
-                  Verify rate: {toPercent(funnel.marketplace.listingsVerified, funnel.marketplace.listingsCreated)}
+                <p className="text-zinc-200">
+                  Listings Created: {funnel.marketplace7d.listingsCreated} ({funnel.shortWindowDays}d) •{" "}
+                  {funnel.marketplace30d.listingsCreated} ({funnel.longWindowDays}d)
                 </p>
               </div>
               <div className="rounded border border-zinc-800 px-3 py-2">
-                <p className="text-zinc-200">Listing Unlock Actions: {funnel.marketplace.listingUnlocks}</p>
+                <p className="text-zinc-200">
+                  Ownership Verified: {funnel.marketplace7d.listingsVerified} ({funnel.shortWindowDays}d) •{" "}
+                  {funnel.marketplace30d.listingsVerified} ({funnel.longWindowDays}d)
+                </p>
+                <p className="text-xs text-zinc-500">
+                  Verify rate: {toPercent(funnel.marketplace7d.listingsVerified, funnel.marketplace7d.listingsCreated)}{" "}
+                  / {toPercent(funnel.marketplace30d.listingsVerified, funnel.marketplace30d.listingsCreated)}
+                </p>
+              </div>
+              <div className="rounded border border-zinc-800 px-3 py-2">
+                <p className="text-zinc-200">
+                  Listing Unlock Actions: {funnel.marketplace7d.listingUnlocks} ({funnel.shortWindowDays}d) •{" "}
+                  {funnel.marketplace30d.listingUnlocks} ({funnel.longWindowDays}d)
+                </p>
                 <p className="text-xs text-zinc-500">
                   Unlocks per verified listing:{" "}
-                  {toPercent(funnel.marketplace.listingUnlocks, funnel.marketplace.listingsVerified)}
+                  {toPercent(funnel.marketplace7d.listingUnlocks, funnel.marketplace7d.listingsVerified)} /{" "}
+                  {toPercent(funnel.marketplace30d.listingUnlocks, funnel.marketplace30d.listingsVerified)}
                 </p>
               </div>
               <div className="rounded border border-zinc-800 px-3 py-2">
-                <p className="text-zinc-200">Connect Purchases: {funnel.marketplace.connectPurchases}</p>
+                <p className="text-zinc-200">
+                  Connect Purchases: {funnel.marketplace7d.connectPurchases} ({funnel.shortWindowDays}d) •{" "}
+                  {funnel.marketplace30d.connectPurchases} ({funnel.longWindowDays}d)
+                </p>
                 <p className="text-xs text-zinc-500">
                   Purchase rate vs unlocks:{" "}
-                  {toPercent(funnel.marketplace.connectPurchases, funnel.marketplace.listingUnlocks)}
+                  {toPercent(funnel.marketplace7d.connectPurchases, funnel.marketplace7d.listingUnlocks)} /{" "}
+                  {toPercent(funnel.marketplace30d.connectPurchases, funnel.marketplace30d.listingUnlocks)}
                 </p>
               </div>
             </div>
@@ -315,26 +332,75 @@ export default async function AdminPage({ searchParams }: Props) {
             <p className="text-xs uppercase tracking-wide text-zinc-500">Beta Testing Funnel</p>
             <div className="mt-3 grid grid-cols-1 gap-2 text-sm">
               <div className="rounded border border-zinc-800 px-3 py-2">
-                <p className="text-zinc-200">Beta Tests Posted: {funnel.beta.betaTestsPosted}</p>
-              </div>
-              <div className="rounded border border-zinc-800 px-3 py-2">
-                <p className="text-zinc-200">Applications Submitted: {funnel.beta.betaApplications}</p>
-                <p className="text-xs text-zinc-500">
-                  Applications per beta: {toPercent(funnel.beta.betaApplications, funnel.beta.betaTestsPosted)}
+                <p className="text-zinc-200">
+                  Beta Tests Posted: {funnel.beta7d.betaTestsPosted} ({funnel.shortWindowDays}d) •{" "}
+                  {funnel.beta30d.betaTestsPosted} ({funnel.longWindowDays}d)
                 </p>
               </div>
               <div className="rounded border border-zinc-800 px-3 py-2">
-                <p className="text-zinc-200">Applicants Approved: {funnel.beta.betaAccepted}</p>
+                <p className="text-zinc-200">
+                  Applications Submitted: {funnel.beta7d.betaApplications} ({funnel.shortWindowDays}d) •{" "}
+                  {funnel.beta30d.betaApplications} ({funnel.longWindowDays}d)
+                </p>
                 <p className="text-xs text-zinc-500">
-                  Approval rate: {toPercent(funnel.beta.betaAccepted, funnel.beta.betaApplications)}
+                  Applications per beta: {toPercent(funnel.beta7d.betaApplications, funnel.beta7d.betaTestsPosted)} /{" "}
+                  {toPercent(funnel.beta30d.betaApplications, funnel.beta30d.betaTestsPosted)}
                 </p>
               </div>
               <div className="rounded border border-zinc-800 px-3 py-2">
-                <p className="text-zinc-200">Feedback Submitted: {funnel.beta.betaFeedbackSubmitted}</p>
+                <p className="text-zinc-200">
+                  Applicants Approved: {funnel.beta7d.betaAccepted} ({funnel.shortWindowDays}d) •{" "}
+                  {funnel.beta30d.betaAccepted} ({funnel.longWindowDays}d)
+                </p>
+                <p className="text-xs text-zinc-500">
+                  Approval rate: {toPercent(funnel.beta7d.betaAccepted, funnel.beta7d.betaApplications)} /{" "}
+                  {toPercent(funnel.beta30d.betaAccepted, funnel.beta30d.betaApplications)}
+                </p>
+              </div>
+              <div className="rounded border border-zinc-800 px-3 py-2">
+                <p className="text-zinc-200">
+                  Feedback Submitted: {funnel.beta7d.betaFeedbackSubmitted} ({funnel.shortWindowDays}d) •{" "}
+                  {funnel.beta30d.betaFeedbackSubmitted} ({funnel.longWindowDays}d)
+                </p>
                 <p className="text-xs text-zinc-500">
                   Feedback completion rate:{" "}
-                  {toPercent(funnel.beta.betaFeedbackSubmitted, funnel.beta.betaAccepted)}
+                  {toPercent(funnel.beta7d.betaFeedbackSubmitted, funnel.beta7d.betaAccepted)} /{" "}
+                  {toPercent(funnel.beta30d.betaFeedbackSubmitted, funnel.beta30d.betaAccepted)}
                 </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-md border border-zinc-800 bg-zinc-950/60 p-3">
+            <p className="text-xs uppercase tracking-wide text-zinc-500">
+              Payment Interest Split ({funnel.longWindowDays}d)
+            </p>
+            <div className="mt-3 grid grid-cols-1 gap-3 text-sm">
+              <div>
+                <p className="text-xs text-zinc-500">Top countries</p>
+                <div className="mt-1 space-y-1">
+                  {funnel.topInterestCountries.length === 0 && (
+                    <p className="text-xs text-zinc-600">No interest signals yet.</p>
+                  )}
+                  {funnel.topInterestCountries.map((row) => (
+                    <p key={`country-${row.label}`} className="text-zinc-300">
+                      {row.label}: <span className="text-zinc-50">{row.count}</span>
+                    </p>
+                  ))}
+                </div>
+              </div>
+              <div>
+                <p className="text-xs text-zinc-500">Top currencies</p>
+                <div className="mt-1 space-y-1">
+                  {funnel.topInterestCurrencies.length === 0 && (
+                    <p className="text-xs text-zinc-600">No currency signals yet.</p>
+                  )}
+                  {funnel.topInterestCurrencies.map((row) => (
+                    <p key={`currency-${row.label}`} className="text-zinc-300">
+                      {row.label}: <span className="text-zinc-50">{row.count}</span>
+                    </p>
+                  ))}
+                </div>
               </div>
             </div>
           </div>

--- a/src/app/beta/beta-client.tsx
+++ b/src/app/beta/beta-client.tsx
@@ -25,6 +25,7 @@ export function BetaPageClient({ betaTests, draftBetaTests, canViewDrafts, topTe
   const reduceMotion = useReducedMotion();
   const [search, setSearch] = useState("");
   const [statusFilter, setStatusFilter] = useState("");
+  const [fundedCashOnly, setFundedCashOnly] = useState(false);
 
   const filtered = useMemo(() => {
     const source = statusFilter === "draft" ? draftBetaTests : betaTests;
@@ -36,10 +37,13 @@ export function BetaPageClient({ betaTests, draftBetaTests, canViewDrafts, topTe
     if (statusFilter && statusFilter !== "draft") {
       result = result.filter((bt) => bt.status === statusFilter);
     }
+    if (fundedCashOnly) {
+      result = result.filter((bt) => bt.reward.type === "cash" && bt.reward.poolStatus === "funded");
+    }
     return result;
-  }, [betaTests, draftBetaTests, search, statusFilter]);
+  }, [betaTests, draftBetaTests, search, statusFilter, fundedCashOnly]);
 
-  const gridKey = `${statusFilter}:${search.trim().toLowerCase()}:${filtered.length}`;
+  const gridKey = `${statusFilter}:${fundedCashOnly}:${search.trim().toLowerCase()}:${filtered.length}`;
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
@@ -83,7 +87,12 @@ export function BetaPageClient({ betaTests, draftBetaTests, canViewDrafts, topTe
               ].map((status) => (
                 <button
                   key={status}
-                  onClick={() => setStatusFilter(status)}
+                  onClick={() => {
+                    setStatusFilter(status);
+                    if (status === "draft") {
+                      setFundedCashOnly(false);
+                    }
+                  }}
                   className={`relative overflow-hidden rounded-full px-3 py-1 text-sm transition-colors ${
                     statusFilter === status ? "text-white" : "bg-zinc-800 text-zinc-400 hover:text-zinc-50"
                   }`}
@@ -108,6 +117,17 @@ export function BetaPageClient({ betaTests, draftBetaTests, canViewDrafts, topTe
                   </span>
                 </button>
               ))}
+              <button
+                onClick={() => setFundedCashOnly((prev) => !prev)}
+                disabled={statusFilter === "draft"}
+                className={`rounded-full px-3 py-1 text-sm transition-colors ${
+                  fundedCashOnly
+                    ? "bg-emerald-600 text-white hover:bg-emerald-500"
+                    : "bg-zinc-800 text-zinc-400 hover:text-zinc-50"
+                } disabled:cursor-not-allowed disabled:opacity-50`}
+              >
+                Funded cash only
+              </button>
             </div>
           </div>
           {filtered.length === 0 ? (

--- a/src/app/browse/browse-client.tsx
+++ b/src/app/browse/browse-client.tsx
@@ -18,6 +18,7 @@ export function BrowseClient({ initialListings }: BrowseClientProps) {
   const reduceMotion = useReducedMotion();
   const [search, setSearch] = useState("");
   const [category, setCategory] = useState("");
+  const [verifiedOnly, setVerifiedOnly] = useState(false);
   const [sortBy, setSortBy] = useState("newest");
   const [minPrice, setMinPrice] = useState("");
   const [maxPrice, setMaxPrice] = useState("");
@@ -33,6 +34,7 @@ export function BrowseClient({ initialListings }: BrowseClientProps) {
       );
     }
     if (category) result = result.filter((l) => l.category === category);
+    if (verifiedOnly) result = result.filter((l) => l.ownershipVerified);
     if (minPrice) result = result.filter((l) => l.askingPrice >= Number(minPrice) * 100);
     if (maxPrice) result = result.filter((l) => l.askingPrice <= Number(maxPrice) * 100);
 
@@ -43,20 +45,29 @@ export function BrowseClient({ initialListings }: BrowseClientProps) {
       default: result.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
     }
     return result;
-  }, [initialListings, search, category, sortBy, minPrice, maxPrice]);
+  }, [initialListings, search, category, verifiedOnly, sortBy, minPrice, maxPrice]);
 
   const activeFilters = [
     search && { label: `"${search}"`, onRemove: () => setSearch("") },
     category && { label: CATEGORY_LABELS[category], onRemove: () => setCategory("") },
+    verifiedOnly && { label: "Verified only", onRemove: () => setVerifiedOnly(false) },
     minPrice && { label: `Min $${minPrice}`, onRemove: () => setMinPrice("") },
     maxPrice && { label: `Max $${maxPrice}`, onRemove: () => setMaxPrice("") },
   ].filter(Boolean) as { label: string; onRemove: () => void }[];
 
-  const clearAll = () => { setSearch(""); setCategory(""); setMinPrice(""); setMaxPrice(""); setSortBy("newest"); };
+  const clearAll = () => {
+    setSearch("");
+    setCategory("");
+    setVerifiedOnly(false);
+    setMinPrice("");
+    setMaxPrice("");
+    setSortBy("newest");
+  };
 
   const filtersProps = {
     search, onSearchChange: setSearch,
     selectedCategory: category, onCategoryChange: setCategory,
+    verifiedOnly, onVerifiedOnlyChange: setVerifiedOnly,
     sortBy, onSortChange: setSortBy,
     minPrice, onMinPriceChange: setMinPrice,
     maxPrice, onMaxPriceChange: setMaxPrice,

--- a/src/components/listing/listing-filters.tsx
+++ b/src/components/listing/listing-filters.tsx
@@ -8,6 +8,8 @@ interface ListingFiltersProps {
   onSearchChange: (value: string) => void;
   selectedCategory: string;
   onCategoryChange: (value: string) => void;
+  verifiedOnly: boolean;
+  onVerifiedOnlyChange: (value: boolean) => void;
   sortBy: string;
   onSortChange: (value: string) => void;
   minPrice: string;
@@ -21,6 +23,8 @@ export function ListingFilters({
   onSearchChange,
   selectedCategory,
   onCategoryChange,
+  verifiedOnly,
+  onVerifiedOnlyChange,
   sortBy,
   onSortChange,
   minPrice,
@@ -84,6 +88,21 @@ export function ListingFilters({
             />
           </div>
         </div>
+      </div>
+
+      <div>
+        <h3 className="mb-3 text-sm font-semibold text-zinc-50">Trust</h3>
+        <button
+          type="button"
+          onClick={() => onVerifiedOnlyChange(!verifiedOnly)}
+          className={`w-full rounded-md border px-3 py-2 text-left text-sm transition-colors ${
+            verifiedOnly
+              ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-200"
+              : "border-zinc-800 bg-zinc-900 text-zinc-400 hover:text-zinc-50"
+          }`}
+        >
+          {verifiedOnly ? "Verified listings only" : "Show all verification states"}
+        </button>
       </div>
 
       <div>

--- a/src/lib/db/admin.ts
+++ b/src/lib/db/admin.ts
@@ -160,20 +160,34 @@ export interface AdminRecentUserItem {
   createdAt: string;
 }
 
+export interface AdminMarketplaceFunnelCounts {
+  listingsCreated: number;
+  listingsVerified: number;
+  listingUnlocks: number;
+  connectPurchases: number;
+}
+
+export interface AdminBetaFunnelCounts {
+  betaTestsPosted: number;
+  betaApplications: number;
+  betaAccepted: number;
+  betaFeedbackSubmitted: number;
+}
+
+export interface AdminGrowthBreakdownItem {
+  label: string;
+  count: number;
+}
+
 export interface AdminGrowthFunnelSnapshot {
-  lookbackDays: number;
-  marketplace: {
-    listingsCreated: number;
-    listingsVerified: number;
-    listingUnlocks: number;
-    connectPurchases: number;
-  };
-  beta: {
-    betaTestsPosted: number;
-    betaApplications: number;
-    betaAccepted: number;
-    betaFeedbackSubmitted: number;
-  };
+  shortWindowDays: number;
+  longWindowDays: number;
+  marketplace7d: AdminMarketplaceFunnelCounts;
+  marketplace30d: AdminMarketplaceFunnelCounts;
+  beta7d: AdminBetaFunnelCounts;
+  beta30d: AdminBetaFunnelCounts;
+  topInterestCountries: AdminGrowthBreakdownItem[];
+  topInterestCurrencies: AdminGrowthBreakdownItem[];
 }
 
 export interface AdminPayoutAuditItem {
@@ -252,8 +266,10 @@ async function exactCount(queryPromise: PromiseLike<unknown>): Promise<number> {
 export async function getAdminDashboardSnapshot(): Promise<AdminDashboardSnapshot> {
   const client = createServiceClient();
   const adminNotificationsPromise = getActiveAdminNotifications(120);
-  const lookbackDays = 30;
-  const lookbackDate = new Date(Date.now() - lookbackDays * 24 * 60 * 60 * 1000).toISOString();
+  const shortWindowDays = 7;
+  const longWindowDays = 30;
+  const shortWindowDate = new Date(Date.now() - shortWindowDays * 24 * 60 * 60 * 1000).toISOString();
+  const longWindowDate = new Date(Date.now() - longWindowDays * 24 * 60 * 60 * 1000).toISOString();
 
   const [
     totalUsers,
@@ -266,6 +282,14 @@ export async function getAdminDashboardSnapshot(): Promise<AdminDashboardSnapsho
     fundedCashBetaTests,
     pendingCashPools,
     manualReviewRequests,
+    listingsCreated7d,
+    listingsVerified7d,
+    listingUnlocks7d,
+    connectPurchases7d,
+    betaTestsPosted7d,
+    betaApplications7d,
+    betaAccepted7d,
+    betaFeedbackSubmitted7d,
     listingsCreated30d,
     listingsVerified30d,
     listingUnlocks30d,
@@ -315,46 +339,88 @@ export async function getAdminDashboardSnapshot(): Promise<AdminDashboardSnapsho
         .eq("status", "manual_requested")
     ),
     exactCount(
-      client.from("listings").select("id", { head: true, count: "exact" }).gte("created_at", lookbackDate)
+      client.from("listings").select("id", { head: true, count: "exact" }).gte("created_at", shortWindowDate)
     ),
     exactCount(
       client
         .from("listings")
         .select("id", { head: true, count: "exact" })
         .eq("ownership_verified", true)
-        .gte("ownership_verified_at", lookbackDate)
+        .gte("ownership_verified_at", shortWindowDate)
     ),
     exactCount(
       client
         .from("unlocked_listings")
         .select("id", { head: true, count: "exact" })
-        .gte("created_at", lookbackDate)
+        .gte("created_at", shortWindowDate)
     ),
     exactCount(
       client
         .from("connects_transactions")
         .select("id", { head: true, count: "exact" })
         .eq("type", "purchase_razorpay")
-        .gte("created_at", lookbackDate)
+        .gte("created_at", shortWindowDate)
     ),
     exactCount(
-      client.from("beta_tests").select("id", { head: true, count: "exact" }).gte("created_at", lookbackDate)
+      client.from("beta_tests").select("id", { head: true, count: "exact" }).gte("created_at", shortWindowDate)
     ),
     exactCount(
       client
         .from("beta_applications")
         .select("beta_test_id", { head: true, count: "exact" })
-        .gte("created_at", lookbackDate)
+        .gte("created_at", shortWindowDate)
     ),
     exactCount(
       client
         .from("beta_applications")
         .select("beta_test_id", { head: true, count: "exact" })
         .eq("status", "accepted")
-        .gte("created_at", lookbackDate)
+        .gte("created_at", shortWindowDate)
     ),
     exactCount(
-      client.from("beta_feedback").select("id", { head: true, count: "exact" }).gte("created_at", lookbackDate)
+      client.from("beta_feedback").select("id", { head: true, count: "exact" }).gte("created_at", shortWindowDate)
+    ),
+    exactCount(
+      client.from("listings").select("id", { head: true, count: "exact" }).gte("created_at", longWindowDate)
+    ),
+    exactCount(
+      client
+        .from("listings")
+        .select("id", { head: true, count: "exact" })
+        .eq("ownership_verified", true)
+        .gte("ownership_verified_at", longWindowDate)
+    ),
+    exactCount(
+      client
+        .from("unlocked_listings")
+        .select("id", { head: true, count: "exact" })
+        .gte("created_at", longWindowDate)
+    ),
+    exactCount(
+      client
+        .from("connects_transactions")
+        .select("id", { head: true, count: "exact" })
+        .eq("type", "purchase_razorpay")
+        .gte("created_at", longWindowDate)
+    ),
+    exactCount(
+      client.from("beta_tests").select("id", { head: true, count: "exact" }).gte("created_at", longWindowDate)
+    ),
+    exactCount(
+      client
+        .from("beta_applications")
+        .select("beta_test_id", { head: true, count: "exact" })
+        .gte("created_at", longWindowDate)
+    ),
+    exactCount(
+      client
+        .from("beta_applications")
+        .select("beta_test_id", { head: true, count: "exact" })
+        .eq("status", "accepted")
+        .gte("created_at", longWindowDate)
+    ),
+    exactCount(
+      client.from("beta_feedback").select("id", { head: true, count: "exact" }).gte("created_at", longWindowDate)
     ),
   ]);
 
@@ -397,7 +463,16 @@ export async function getAdminDashboardSnapshot(): Promise<AdminDashboardSnapsho
     payoutRowsRaw = (fallbackResult.data ?? []) as RawCashPayoutRow[];
   }
 
-  const [premiumQueueResult, verificationQueueResult, betaPaymentsResult, connectPurchasesResult, signalsResult, recentUsersResult, payoutAuditResult] =
+  const [
+    premiumQueueResult,
+    verificationQueueResult,
+    betaPaymentsResult,
+    connectPurchasesResult,
+    signalsResult,
+    recentUsersResult,
+    payoutAuditResult,
+    interestBreakdownResult,
+  ] =
     await Promise.all([
       client
         .from("beta_applications")
@@ -435,6 +510,12 @@ export async function getAdminDashboardSnapshot(): Promise<AdminDashboardSnapsho
         .select("id, beta_test_id, applicant_user_id, previous_status, next_status, payout_note, admin_user_id, created_at")
         .order("created_at", { ascending: false })
         .limit(200),
+      client
+        .from("payment_interest_signals")
+        .select("country_code, currency, created_at")
+        .gte("created_at", longWindowDate)
+        .order("created_at", { ascending: false })
+        .limit(2000),
     ]);
 
   const cashPayoutQueueBase = payoutRowsRaw
@@ -678,20 +759,62 @@ export async function getAdminDashboardSnapshot(): Promise<AdminDashboardSnapsho
     (sum, row) => sum + Math.max(0, row.payoutFeeMinor),
     0
   );
+
+  const interestBreakdownRows = (interestBreakdownResult.data ?? []) as Record<string, unknown>[];
+  const countryCounts = new Map<string, number>();
+  const currencyCounts = new Map<string, number>();
+  for (const row of interestBreakdownRows) {
+    const country =
+      typeof row.country_code === "string" && row.country_code.trim().length > 0
+        ? row.country_code.trim().toUpperCase()
+        : "Unknown";
+    const currency =
+      typeof row.currency === "string" && row.currency.trim().length > 0
+        ? row.currency.trim().toUpperCase()
+        : "UNKNOWN";
+    countryCounts.set(country, (countryCounts.get(country) ?? 0) + 1);
+    currencyCounts.set(currency, (currencyCounts.get(currency) ?? 0) + 1);
+  }
+
+  const topInterestCountries = Array.from(countryCounts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 8)
+    .map(([label, count]) => ({ label, count }));
+
+  const topInterestCurrencies = Array.from(currencyCounts.entries())
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
+    .slice(0, 8)
+    .map(([label, count]) => ({ label, count }));
+
   const growthFunnel: AdminGrowthFunnelSnapshot = {
-    lookbackDays,
-    marketplace: {
+    shortWindowDays,
+    longWindowDays,
+    marketplace7d: {
+      listingsCreated: listingsCreated7d,
+      listingsVerified: listingsVerified7d,
+      listingUnlocks: listingUnlocks7d,
+      connectPurchases: connectPurchases7d,
+    },
+    marketplace30d: {
       listingsCreated: listingsCreated30d,
       listingsVerified: listingsVerified30d,
       listingUnlocks: listingUnlocks30d,
       connectPurchases: connectPurchases30d,
     },
-    beta: {
+    beta7d: {
+      betaTestsPosted: betaTestsPosted7d,
+      betaApplications: betaApplications7d,
+      betaAccepted: betaAccepted7d,
+      betaFeedbackSubmitted: betaFeedbackSubmitted7d,
+    },
+    beta30d: {
       betaTestsPosted: betaTestsPosted30d,
       betaApplications: betaApplications30d,
       betaAccepted: betaAccepted30d,
       betaFeedbackSubmitted: betaFeedbackSubmitted30d,
     },
+    topInterestCountries,
+    topInterestCurrencies,
   };
   const persistedNotifications = await adminNotificationsPromise;
 


### PR DESCRIPTION
## Summary
- expand admin funnel to 7d vs 30d trends
- add payment-interest split by country/currency
- add trust filters: verified-only on /browse and funded-cash-only on /beta
- add scheduled uptime workflow for public and cron endpoints

## Validation
- npm run lint
- npm run test
- npm run build