### PR TITLE
Add nightly production smoke tests and security headers

### DIFF
--- a/.github/workflows/nightly-prod-smoke.yml
+++ b/.github/workflows/nightly-prod-smoke.yml
@@ -1,0 +1,41 @@
+name: Nightly Production Smoke
+
+on:
+  schedule:
+    - cron: "30 2 * * *"
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    name: Playwright Production Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      PLAYWRIGHT_BASE_URL: ${{ secrets.APP_BASE_URL || 'https://sideflip.vercel.app' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run production smoke tests
+        run: npx playwright test tests/e2e/public-smoke.spec.ts tests/e2e/auth-and-seo.spec.ts --project=chromium
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-prod-smoke
+          path: playwright-report
+          if-no-files-found: ignore
+          retention-days: 14

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ npm run build
   - `/api/cron/admin/daily-payout-summary` (when `CRON_SECRET` secret is set)
   - `/api/cron/admin/payout-reconciliation` (when `CRON_SECRET` secret is set)
 - `Uptime Alerts` workflow opens an incident issue automatically if uptime fails on `main`, and auto-closes it after recovery.
+- `Nightly Production Smoke` workflow runs Playwright against production every day and validates:
+  - `/`, `/browse`, `/beta`, `/how-it-works`, `/terms`, `/privacy`, `/refund`
+  - signed-out redirects on `/dashboard` and `/connects`
+  - `/robots.txt`, `/sitemap.xml`, and Google verification file reachability
 
 Recommended GitHub repo secrets:
 - `APP_BASE_URL` (optional, defaults to `https://sideflip.vercel.app`)

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,55 @@
 import type { NextConfig } from "next";
 import { withSentryConfig } from "@sentry/nextjs";
 
-const nextConfig: NextConfig = {};
+const isProd = process.env.NODE_ENV === "production";
+
+const contentSecurityPolicy = [
+  "default-src 'self'",
+  "base-uri 'self'",
+  "form-action 'self' https:",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data: https:",
+  "style-src 'self' 'unsafe-inline' https:",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https:",
+  "connect-src 'self' https: wss:",
+  "frame-src 'self' https:",
+  "worker-src 'self' blob:",
+  ...(isProd ? ["upgrade-insecure-requests"] : []),
+].join("; ");
+
+const securityHeaders: Array<{ key: string; value: string }> = [
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), payment=(), usb=()",
+  },
+  { key: "Cross-Origin-Opener-Policy", value: "same-origin" },
+  { key: "Cross-Origin-Resource-Policy", value: "same-site" },
+  { key: "Content-Security-Policy", value: contentSecurityPolicy },
+  ...(isProd
+    ? [
+        {
+          key: "Strict-Transport-Security",
+          value: "max-age=63072000; includeSubDomains; preload",
+        },
+      ]
+    : []),
+];
+
+const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
+};
 
 const sentryWebpackPluginOptions = {
   org: process.env.SENTRY_ORG,


### PR DESCRIPTION
## Summary
- add nightly Playwright production smoke workflow
- harden Next.js security headers (CSP, XFO, HSTS in production, and related headers)
- document the new workflow and route coverage in README

## Validation
- npm run lint
- npm run build
- npm run test:e2e