### PR TITLE
Add release drafter automation

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,47 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
+change-title-escapes: "\\<*_&"
+template: |
+  ## Changes
+
+  $CHANGES
+
+  ## Contributors
+
+  $CONTRIBUTORS
+
+categories:
+  - title: "Features"
+    labels:
+      - "feature"
+      - "enhancement"
+  - title: "Fixes"
+    labels:
+      - "bug"
+      - "fix"
+  - title: "Ops"
+    labels:
+      - "ops"
+      - "infra"
+      - "security"
+  - title: "Documentation"
+    labels:
+      - "docs"
+
+exclude-labels:
+  - "skip-changelog"
+
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  patch:
+    labels:
+      - "patch"
+      - "fix"
+      - "bug"
+  default: patch

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,20 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: read
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Draft release notes
+        uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ npm run build
   - `/`, `/browse`, `/beta`, `/how-it-works`, `/terms`, `/privacy`, `/refund`
   - signed-out redirects on `/dashboard` and `/connects`
   - `/robots.txt`, `/sitemap.xml`, and Google verification file reachability
+- `Release Drafter` workflow updates a draft GitHub release on each `main` push using merged PR titles and labels.
 
 Recommended GitHub repo secrets:
 - `APP_BASE_URL` (optional, defaults to `https://sideflip.vercel.app`)


### PR DESCRIPTION
## Summary
- add Release Drafter workflow on pushes to main
- add release drafter config using PR titles/labels
- document release drafter in README

## Validation
- npm run lint