### PR TITLE
Add non-India waitlist conversion tracking and regional messaging

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -376,6 +376,49 @@ export default async function AdminPage({ searchParams }: Props) {
               Payment Interest Split ({funnel.longWindowDays}d)
             </p>
             <div className="mt-3 grid grid-cols-1 gap-3 text-sm">
+              <div className="rounded border border-zinc-800 px-3 py-2">
+                <p className="text-zinc-200">
+                  Connects waitlist conversion:{" "}
+                  <span className="text-zinc-50">
+                    {funnel.waitlistConversion.connectsInterested} / {funnel.waitlistConversion.connectsViews}
+                  </span>
+                </p>
+                <p className="text-xs text-zinc-500">
+                  Interested rate:{" "}
+                  {toPercent(
+                    funnel.waitlistConversion.connectsInterested,
+                    funnel.waitlistConversion.connectsViews
+                  )}
+                </p>
+                <p className="mt-1 text-zinc-200">
+                  Beta funding waitlist conversion:{" "}
+                  <span className="text-zinc-50">
+                    {funnel.waitlistConversion.betaFundingInterested} /{" "}
+                    {funnel.waitlistConversion.betaFundingViews}
+                  </span>
+                </p>
+                <p className="text-xs text-zinc-500">
+                  Interested rate:{" "}
+                  {toPercent(
+                    funnel.waitlistConversion.betaFundingInterested,
+                    funnel.waitlistConversion.betaFundingViews
+                  )}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs text-zinc-500">Top waitlist countries (views → interested)</p>
+                <div className="mt-1 space-y-1">
+                  {funnel.waitlistConversion.topCountries.length === 0 && (
+                    <p className="text-xs text-zinc-600">No waitlist conversion data yet.</p>
+                  )}
+                  {funnel.waitlistConversion.topCountries.map((row) => (
+                    <p key={`waitlist-country-${row.countryCode}`} className="text-zinc-300">
+                      {row.countryCode}: C {row.connectsInterested}/{row.connectsViews} • B{" "}
+                      {row.betaFundingInterested}/{row.betaFundingViews}
+                    </p>
+                  ))}
+                </div>
+              </div>
               <div>
                 <p className="text-xs text-zinc-500">Top countries</p>
                 <div className="mt-1 space-y-1">

--- a/src/app/beta/[id]/funding-card.tsx
+++ b/src/app/beta/[id]/funding-card.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
+import {
+  BETA_REWARD_FUNDING_INTEREST_FEATURE,
+  BETA_REWARD_FUNDING_WAITLIST_VIEW_FEATURE,
+} from "@/lib/payments/interest-features";
+import { getNonIndiaPaymentsWaitlistCopy } from "@/lib/payments/waitlist-copy";
+import { shouldTrackWaitlistViewClient } from "@/lib/payments/waitlist-tracking";
 
 type PoolStatus = "not_required" | "pending" | "partial" | "funded";
 type RewardType = "cash" | "premium_access";
@@ -86,6 +92,44 @@ export function FundingCard({
   const [markingInterest, setMarkingInterest] = useState(false);
   const [error, setError] = useState("");
   const [message, setMessage] = useState("");
+  const waitlistCopy = getNonIndiaPaymentsWaitlistCopy(countryCode, rewardCurrency);
+  const remainingMinor = Math.max(0, poolTotalMinor - poolFundedMinor);
+  const funded = poolStatus === "funded" || remainingMinor === 0;
+
+  useEffect(() => {
+    if (!isCreator || funded || paymentsEnabledForCountry) return;
+    const viewKey = `beta_funding:${betaTestId}:${countryCode || "unknown"}:${rewardCurrency}`;
+    if (!shouldTrackWaitlistViewClient(viewKey)) return;
+
+    void fetch("/api/payments/interest", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        feature: BETA_REWARD_FUNDING_WAITLIST_VIEW_FEATURE,
+        context: {
+          source: "beta_funding_card",
+          event: "waitlist_view",
+          route: `/beta/${betaTestId}`,
+          betaTestId,
+          rewardCurrency,
+          poolTotalMinor,
+          poolFundedMinor,
+          countryCode,
+        },
+      }),
+    }).catch(() => {
+      // Non-blocking telemetry for conversion tracking.
+    });
+  }, [
+    betaTestId,
+    countryCode,
+    funded,
+    isCreator,
+    paymentsEnabledForCountry,
+    poolFundedMinor,
+    poolTotalMinor,
+    rewardCurrency,
+  ]);
 
   if (rewardType !== "cash" || poolTotalMinor <= 0) {
     return (
@@ -95,9 +139,6 @@ export function FundingCard({
       </div>
     );
   }
-
-  const remainingMinor = Math.max(0, poolTotalMinor - poolFundedMinor);
-  const funded = poolStatus === "funded" || remainingMinor === 0;
 
   const handleFund = async () => {
     if (!isCreator || funded || loading) return;
@@ -189,8 +230,11 @@ export function FundingCard({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          feature: "beta_reward_funding",
+          feature: BETA_REWARD_FUNDING_INTEREST_FEATURE,
           context: {
+            source: "beta_funding_card",
+            event: "waitlist_interested",
+            route: `/beta/${betaTestId}`,
             betaTestId,
             rewardCurrency,
             poolTotalMinor,
@@ -207,7 +251,7 @@ export function FundingCard({
         return;
       }
 
-      setMessage("Marked. We will email you when payments are available in your country.");
+      setMessage(waitlistCopy.successMessage);
       setMarkingInterest(false);
     } catch {
       setError("Could not mark your interest right now.");
@@ -232,7 +276,7 @@ export function FundingCard({
         ) : !paymentsEnabledForCountry ? (
           <div className="mt-3">
             <p className="mb-2 text-xs text-amber-400">
-              Payments are currently available only in India. Mark interested to get notified.
+              {waitlistCopy.availabilityMessage}
             </p>
             <Button
               size="sm"

--- a/src/app/connects/connects-client.tsx
+++ b/src/app/connects/connects-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Zap, Gift, ArrowUpRight, ArrowDownRight, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -8,6 +8,12 @@ import { Badge } from "@/components/ui/badge";
 import { PageHeader } from "@/components/shared/page-header";
 import { getMoreConnectsTransactionsAction, giftConnectsAction } from "./actions";
 import type { Currency } from "@/lib/geo";
+import {
+  CONNECTS_PAYMENT_INTEREST_FEATURE,
+  CONNECTS_PAYMENT_WAITLIST_VIEW_FEATURE,
+} from "@/lib/payments/interest-features";
+import { getNonIndiaPaymentsWaitlistCopy } from "@/lib/payments/waitlist-copy";
+import { shouldTrackWaitlistViewClient } from "@/lib/payments/waitlist-tracking";
 
 const BUNDLES: Record<Currency, Array<{ connects: number; price: string; description: string; popular?: boolean }>> = {
   USD: [
@@ -122,7 +128,32 @@ export function ConnectsClient({
   const [purchaseMessage, setPurchaseMessage] = useState("");
 
   const bundles = BUNDLES[currency];
+  const waitlistCopy = getNonIndiaPaymentsWaitlistCopy(countryCode, currency);
   const freeAmount = signupGiftAmount;
+
+  useEffect(() => {
+    if (paymentsEnabledForCountry || currency === "INR") return;
+    const viewKey = `connects:${countryCode || "unknown"}:${currency}`;
+    if (!shouldTrackWaitlistViewClient(viewKey)) return;
+
+    void fetch("/api/payments/interest", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        feature: CONNECTS_PAYMENT_WAITLIST_VIEW_FEATURE,
+        context: {
+          source: "connects_page",
+          event: "waitlist_view",
+          route: "/connects",
+          currency,
+          countryCode,
+          bundles: bundles.map((bundle) => ({ connects: bundle.connects, priceLabel: bundle.price })),
+        },
+      }),
+    }).catch(() => {
+      // Non-blocking telemetry for conversion tracking.
+    });
+  }, [bundles, countryCode, currency, paymentsEnabledForCountry]);
 
   const handleClaim = async () => {
     if (claimed || loading) return;
@@ -239,8 +270,11 @@ export function ConnectsClient({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          feature: "connects_payment",
+          feature: CONNECTS_PAYMENT_INTEREST_FEATURE,
           context: {
+            source: "connects_page",
+            event: "waitlist_interested",
+            route: "/connects",
             connects,
             priceLabel,
             currency,
@@ -254,7 +288,7 @@ export function ConnectsClient({
         setMarkingInterestConnects(null);
         return;
       }
-      setPurchaseMessage("Marked. We will email you when payments are available in your country.");
+      setPurchaseMessage(waitlistCopy.successMessage);
       setMarkingInterestConnects(null);
     } catch {
       setPurchaseError("Could not mark your interest right now.");
@@ -384,7 +418,7 @@ export function ConnectsClient({
       <p className="text-xs text-zinc-600 mb-10 text-center">
         {paymentsEnabledForCountry && currency === "INR"
           ? "INR payments are live via Razorpay. Unlock cost scales by listing price (starts at 2 connects)."
-          : "Payments are currently available only in India. Mark interested and we will email you when your country goes live."}
+          : waitlistCopy.availabilityMessage}
       </p>
       {purchaseError && <p className="text-xs text-red-400 mb-4 text-center">{purchaseError}</p>}
       {purchaseMessage && <p className="text-xs text-green-400 mb-4 text-center">{purchaseMessage}</p>}

--- a/src/lib/db/admin.ts
+++ b/src/lib/db/admin.ts
@@ -1,7 +1,14 @@
 import "server-only";
 import { createServiceClient } from "@/lib/supabase";
 import { calculateCashBetaPayout } from "@/lib/payments/beta-payouts";
-import { PAYMENT_INTEREST_FEATURES } from "@/lib/payments/interest-features";
+import {
+  BETA_REWARD_FUNDING_INTEREST_FEATURE,
+  BETA_REWARD_FUNDING_WAITLIST_VIEW_FEATURE,
+  CONNECTS_PAYMENT_INTEREST_FEATURE,
+  CONNECTS_PAYMENT_WAITLIST_VIEW_FEATURE,
+  PAYMENT_INTEREST_FEATURES,
+  PAYMENT_INTEREST_MARK_FEATURES,
+} from "@/lib/payments/interest-features";
 import { getActiveAdminNotifications, type AdminNotificationItem } from "@/lib/db/admin-notifications";
 
 type PayoutStatus = "pending" | "paid" | "failed";
@@ -180,6 +187,22 @@ export interface AdminGrowthBreakdownItem {
   count: number;
 }
 
+export interface AdminWaitlistCountryConversion {
+  countryCode: string;
+  connectsViews: number;
+  connectsInterested: number;
+  betaFundingViews: number;
+  betaFundingInterested: number;
+}
+
+export interface AdminWaitlistConversionSnapshot {
+  connectsViews: number;
+  connectsInterested: number;
+  betaFundingViews: number;
+  betaFundingInterested: number;
+  topCountries: AdminWaitlistCountryConversion[];
+}
+
 export interface AdminGrowthFunnelSnapshot {
   shortWindowDays: number;
   longWindowDays: number;
@@ -187,6 +210,7 @@ export interface AdminGrowthFunnelSnapshot {
   marketplace30d: AdminMarketplaceFunnelCounts;
   beta7d: AdminBetaFunnelCounts;
   beta30d: AdminBetaFunnelCounts;
+  waitlistConversion: AdminWaitlistConversionSnapshot;
   topInterestCountries: AdminGrowthBreakdownItem[];
   topInterestCurrencies: AdminGrowthBreakdownItem[];
 }
@@ -499,7 +523,7 @@ export async function getAdminDashboardSnapshot(): Promise<AdminDashboardSnapsho
       client
         .from("payment_interest_signals")
         .select("id, clerk_user_id, feature, country_code, currency, created_at")
-        .in("feature", PAYMENT_INTEREST_FEATURES)
+        .in("feature", PAYMENT_INTEREST_MARK_FEATURES)
         .order("created_at", { ascending: false })
         .limit(200),
       client
@@ -514,7 +538,7 @@ export async function getAdminDashboardSnapshot(): Promise<AdminDashboardSnapsho
         .limit(200),
       client
         .from("payment_interest_signals")
-        .select("country_code, currency, created_at")
+        .select("feature, country_code, currency, created_at")
         .in("feature", PAYMENT_INTEREST_FEATURES)
         .gte("created_at", longWindowDate)
         .order("created_at", { ascending: false })
@@ -766,7 +790,17 @@ export async function getAdminDashboardSnapshot(): Promise<AdminDashboardSnapsho
   const interestBreakdownRows = (interestBreakdownResult.data ?? []) as Record<string, unknown>[];
   const countryCounts = new Map<string, number>();
   const currencyCounts = new Map<string, number>();
+  const waitlistCountryMap = new Map<
+    string,
+    { connectsViews: number; connectsInterested: number; betaFundingViews: number; betaFundingInterested: number }
+  >();
+  let connectsViews = 0;
+  let connectsInterested = 0;
+  let betaFundingViews = 0;
+  let betaFundingInterested = 0;
+
   for (const row of interestBreakdownRows) {
+    const feature = typeof row.feature === "string" ? row.feature : "";
     const country =
       typeof row.country_code === "string" && row.country_code.trim().length > 0
         ? row.country_code.trim().toUpperCase()
@@ -775,8 +809,35 @@ export async function getAdminDashboardSnapshot(): Promise<AdminDashboardSnapsho
       typeof row.currency === "string" && row.currency.trim().length > 0
         ? row.currency.trim().toUpperCase()
         : "UNKNOWN";
-    countryCounts.set(country, (countryCounts.get(country) ?? 0) + 1);
-    currencyCounts.set(currency, (currencyCounts.get(currency) ?? 0) + 1);
+
+    if (
+      feature === CONNECTS_PAYMENT_INTEREST_FEATURE ||
+      feature === BETA_REWARD_FUNDING_INTEREST_FEATURE
+    ) {
+      countryCounts.set(country, (countryCounts.get(country) ?? 0) + 1);
+      currencyCounts.set(currency, (currencyCounts.get(currency) ?? 0) + 1);
+    }
+
+    const countryRow = waitlistCountryMap.get(country) ?? {
+      connectsViews: 0,
+      connectsInterested: 0,
+      betaFundingViews: 0,
+      betaFundingInterested: 0,
+    };
+    if (feature === CONNECTS_PAYMENT_WAITLIST_VIEW_FEATURE) {
+      countryRow.connectsViews += 1;
+      connectsViews += 1;
+    } else if (feature === CONNECTS_PAYMENT_INTEREST_FEATURE) {
+      countryRow.connectsInterested += 1;
+      connectsInterested += 1;
+    } else if (feature === BETA_REWARD_FUNDING_WAITLIST_VIEW_FEATURE) {
+      countryRow.betaFundingViews += 1;
+      betaFundingViews += 1;
+    } else if (feature === BETA_REWARD_FUNDING_INTEREST_FEATURE) {
+      countryRow.betaFundingInterested += 1;
+      betaFundingInterested += 1;
+    }
+    waitlistCountryMap.set(country, countryRow);
   }
 
   const topInterestCountries = Array.from(countryCounts.entries())
@@ -788,6 +849,28 @@ export async function getAdminDashboardSnapshot(): Promise<AdminDashboardSnapsho
     .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
     .slice(0, 8)
     .map(([label, count]) => ({ label, count }));
+
+  const topWaitlistCountries = Array.from(waitlistCountryMap.entries())
+    .filter(([, row]) => row.connectsViews + row.connectsInterested + row.betaFundingViews + row.betaFundingInterested > 0)
+    .sort((a, b) => {
+      const aInterested = a[1].connectsInterested + a[1].betaFundingInterested;
+      const bInterested = b[1].connectsInterested + b[1].betaFundingInterested;
+      if (aInterested !== bInterested) return bInterested - aInterested;
+
+      const aViews = a[1].connectsViews + a[1].betaFundingViews;
+      const bViews = b[1].connectsViews + b[1].betaFundingViews;
+      if (aViews !== bViews) return bViews - aViews;
+
+      return a[0].localeCompare(b[0]);
+    })
+    .slice(0, 8)
+    .map(([countryCode, row]) => ({
+      countryCode,
+      connectsViews: row.connectsViews,
+      connectsInterested: row.connectsInterested,
+      betaFundingViews: row.betaFundingViews,
+      betaFundingInterested: row.betaFundingInterested,
+    }));
 
   const growthFunnel: AdminGrowthFunnelSnapshot = {
     shortWindowDays,
@@ -815,6 +898,13 @@ export async function getAdminDashboardSnapshot(): Promise<AdminDashboardSnapsho
       betaApplications: betaApplications30d,
       betaAccepted: betaAccepted30d,
       betaFeedbackSubmitted: betaFeedbackSubmitted30d,
+    },
+    waitlistConversion: {
+      connectsViews,
+      connectsInterested,
+      betaFundingViews,
+      betaFundingInterested,
+      topCountries: topWaitlistCountries,
     },
     topInterestCountries,
     topInterestCurrencies,

--- a/src/lib/payments/interest-features.ts
+++ b/src/lib/payments/interest-features.ts
@@ -1,6 +1,21 @@
+export const CONNECTS_PAYMENT_INTEREST_FEATURE = "connects_payment" as const;
+export const BETA_REWARD_FUNDING_INTEREST_FEATURE = "beta_reward_funding" as const;
+export const CONNECTS_PAYMENT_WAITLIST_VIEW_FEATURE = "connects_payment_waitlist_view" as const;
+export const BETA_REWARD_FUNDING_WAITLIST_VIEW_FEATURE = "beta_reward_funding_waitlist_view" as const;
+
+export const PAYMENT_INTEREST_MARK_FEATURES = [
+  CONNECTS_PAYMENT_INTEREST_FEATURE,
+  BETA_REWARD_FUNDING_INTEREST_FEATURE,
+] as const;
+
+export const PAYMENT_INTEREST_WAITLIST_VIEW_FEATURES = [
+  CONNECTS_PAYMENT_WAITLIST_VIEW_FEATURE,
+  BETA_REWARD_FUNDING_WAITLIST_VIEW_FEATURE,
+] as const;
+
 export const PAYMENT_INTEREST_FEATURES = [
-  "connects_payment",
-  "beta_reward_funding",
+  ...PAYMENT_INTEREST_MARK_FEATURES,
+  ...PAYMENT_INTEREST_WAITLIST_VIEW_FEATURES,
 ] as const;
 
 export type PaymentInterestFeature = (typeof PAYMENT_INTEREST_FEATURES)[number];

--- a/src/lib/payments/waitlist-copy.ts
+++ b/src/lib/payments/waitlist-copy.ts
@@ -1,0 +1,33 @@
+import type { Currency } from "@/lib/geo";
+
+interface WaitlistCopy {
+  regionLabel: string;
+  availabilityMessage: string;
+  successMessage: string;
+}
+
+const COUNTRY_LABELS: Record<string, string> = {
+  US: "United States",
+  GB: "United Kingdom",
+  CA: "Canada",
+  AU: "Australia",
+  SG: "Singapore",
+  AE: "UAE",
+};
+
+function getRegionLabel(countryCode: string, currency: Currency): string {
+  const normalized = countryCode.trim().toUpperCase();
+  if (COUNTRY_LABELS[normalized]) return COUNTRY_LABELS[normalized];
+  if (currency === "EUR") return "Europe";
+  if (currency === "GBP") return "United Kingdom";
+  return normalized || "your country";
+}
+
+export function getNonIndiaPaymentsWaitlistCopy(countryCode: string, currency: Currency): WaitlistCopy {
+  const regionLabel = getRegionLabel(countryCode, currency);
+  return {
+    regionLabel,
+    availabilityMessage: `Payments are currently live only in India. Join the ${regionLabel} waitlist for early access updates.`,
+    successMessage: `Marked. You're on the ${regionLabel} waitlist and we'll email rollout details.`,
+  };
+}

--- a/src/lib/payments/waitlist-tracking.ts
+++ b/src/lib/payments/waitlist-tracking.ts
@@ -1,0 +1,27 @@
+const WAITLIST_VIEW_TTL_MS = 12 * 60 * 60 * 1000;
+const STORAGE_PREFIX = "sideflip_waitlist_view";
+
+function buildStorageKey(key: string): string {
+  return `${STORAGE_PREFIX}:${key}`;
+}
+
+export function shouldTrackWaitlistViewClient(key: string): boolean {
+  if (typeof window === "undefined") return false;
+
+  try {
+    const storageKey = buildStorageKey(key);
+    const lastTrackedRaw = localStorage.getItem(storageKey);
+    const lastTracked = lastTrackedRaw ? Number(lastTrackedRaw) : 0;
+    const now = Date.now();
+
+    if (Number.isFinite(lastTracked) && lastTracked > 0 && now - lastTracked < WAITLIST_VIEW_TTL_MS) {
+      return false;
+    }
+
+    localStorage.setItem(storageKey, String(now));
+    return true;
+  } catch {
+    // If storage is unavailable, still allow tracking.
+    return true;
+  }
+}


### PR DESCRIPTION
## Summary
- add non-IN waitlist `view` + `interested` conversion tracking for connects and beta funding
- add country-targeted waitlist copy in the UI for non-India users
- add waitlist conversion metrics to admin growth funnel (totals + top countries)
- keep payment-interest country/currency split focused on interested events

## Validation
- npm run lint
- npm test
- npm run build
- npm run test:e2e