### PR TITLE
Add offers, listing boosts, saved alerts, and screenshot uploads

### DIFF
--- a/src/app/api/cron/expire-featured-listings/route.ts
+++ b/src/app/api/cron/expire-featured-listings/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import { expireFeaturedListings } from "@/lib/db/listings";
+
+export const runtime = "nodejs";
+
+function isAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) return process.env.NODE_ENV !== "production";
+  return request.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+export async function GET(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+
+  const expired = await expireFeaturedListings();
+  return NextResponse.json({ ok: true, expired });
+}

--- a/src/app/api/cron/saved-search-alerts/route.ts
+++ b/src/app/api/cron/saved-search-alerts/route.ts
@@ -1,0 +1,92 @@
+import { NextResponse } from "next/server";
+import { getAllPendingSavedSearches, markSavedSearchesNotified } from "@/lib/db/saved-searches";
+import { getListings } from "@/lib/db/listings";
+import { absoluteUrl } from "@/lib/seo";
+import { formatPrice } from "@/lib/data";
+
+export const runtime = "nodejs";
+
+function isAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) return process.env.NODE_ENV !== "production";
+  return request.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+export async function GET(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  const fromEmail = process.env.INTEREST_FROM_EMAIL?.trim() || "SideFlip <onboarding@resend.dev>";
+
+  const [savedSearches, allListings] = await Promise.all([
+    getAllPendingSavedSearches(),
+    getListings(),
+  ]);
+
+  const cutoff = Date.now() - ONE_DAY_MS;
+  const newListings = allListings.filter((l) => new Date(l.createdAt).getTime() > cutoff);
+
+  if (newListings.length === 0 || savedSearches.length === 0) {
+    await markSavedSearchesNotified(savedSearches.map((s) => s.id));
+    return NextResponse.json({ ok: true, sent: 0, reason: "no_new_listings_or_searches" });
+  }
+
+  // Group searches by email
+  const byEmail = new Map<string, typeof savedSearches>();
+  for (const s of savedSearches) {
+    const existing = byEmail.get(s.email) ?? [];
+    existing.push(s);
+    byEmail.set(s.email, existing);
+  }
+
+  let sent = 0;
+  const processedIds: string[] = savedSearches.map((s) => s.id);
+
+  if (apiKey) {
+    for (const [email, searches] of byEmail) {
+      // Find matching listings across all searches for this email
+      const matched = new Map<string, (typeof newListings)[0]>();
+      for (const search of searches) {
+        for (const listing of newListings) {
+          if (matched.has(listing.id)) continue;
+          if (search.category && listing.category !== search.category) continue;
+          if (search.maxPriceCents && listing.askingPrice > search.maxPriceCents) continue;
+          matched.set(listing.id, listing);
+        }
+      }
+
+      if (matched.size === 0) continue;
+
+      const matchedListings = Array.from(matched.values());
+      const count = matchedListings.length;
+      const listingLines = matchedListings
+        .map((l) => `• ${l.title} — ${formatPrice(l.askingPrice)}\n  ${absoluteUrl(`/listing/${l.id}`)}`)
+        .join("\n\n");
+
+      const body = `${count} new project${count !== 1 ? "s" : ""} listed on SideFlip match your saved search:\n\n${listingLines}\n\nBrowse all: ${absoluteUrl("/browse")}\nManage alerts in your dashboard settings.`;
+
+      await fetch("https://api.resend.com/emails", {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          from: fromEmail,
+          to: [email],
+          subject: `[SideFlip] ${count} new listing${count !== 1 ? "s" : ""} match your saved search`,
+          text: body,
+        }),
+      }).catch(() => null);
+
+      sent++;
+    }
+  }
+
+  await markSavedSearchesNotified(processedIds);
+  return NextResponse.json({ ok: true, sent });
+}

--- a/src/app/api/upload/screenshot/route.ts
+++ b/src/app/api/upload/screenshot/route.ts
@@ -1,0 +1,58 @@
+import { auth } from "@clerk/nextjs/server";
+import { createServiceClient } from "@/lib/supabase";
+import { NextResponse } from "next/server";
+import { randomUUID } from "crypto";
+
+const MAX_SIZE = 5 * 1024 * 1024; // 5MB
+const ALLOWED_TYPES = ["image/jpeg", "image/png", "image/webp", "image/gif"];
+const BUCKET = "listing-screenshots";
+
+export async function POST(request: Request) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  const file = formData.get("file") as File | null;
+  if (!file) {
+    return NextResponse.json({ error: "No file provided" }, { status: 400 });
+  }
+
+  if (!ALLOWED_TYPES.includes(file.type)) {
+    return NextResponse.json(
+      { error: "Only JPEG, PNG, WebP, and GIF images are allowed" },
+      { status: 400 }
+    );
+  }
+
+  if (file.size > MAX_SIZE) {
+    return NextResponse.json({ error: "File must be under 5MB" }, { status: 400 });
+  }
+
+  const ext = file.type === "image/jpeg" ? "jpg" : file.type.split("/")[1];
+  const path = `${userId}/${randomUUID()}.${ext}`;
+  const buffer = await file.arrayBuffer();
+
+  const client = createServiceClient();
+  const { error } = await client.storage.from(BUCKET).upload(path, buffer, {
+    contentType: file.type,
+    upsert: false,
+  });
+
+  if (error) {
+    return NextResponse.json(
+      { error: "Upload failed. Make sure the listing-screenshots bucket exists in Supabase." },
+      { status: 500 }
+    );
+  }
+
+  const { data: urlData } = client.storage.from(BUCKET).getPublicUrl(path);
+  return NextResponse.json({ url: urlData.publicUrl });
+}

--- a/src/app/browse/[category]/page.tsx
+++ b/src/app/browse/[category]/page.tsx
@@ -1,0 +1,40 @@
+import { notFound } from "next/navigation";
+import { auth } from "@clerk/nextjs/server";
+import { getListings } from "@/lib/db/listings";
+import { BrowseClient } from "../browse-client";
+import { CATEGORY_LABELS } from "@/lib/constants";
+import { publicPageMetadata } from "@/lib/seo";
+import type { Metadata } from "next";
+
+interface Props { params: Promise<{ category: string }> }
+
+export function generateStaticParams() {
+  return Object.keys(CATEGORY_LABELS).map((category) => ({ category }));
+}
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { category } = await params;
+  const label = CATEGORY_LABELS[category];
+  if (!label) return { title: "Not Found" };
+  return publicPageMetadata({
+    title: `${label} for Sale`,
+    description: `Browse ${label.toLowerCase()} side projects for sale on SideFlip. Real metrics, verified sellers, transparent pricing.`,
+    path: `/browse/${category}`,
+  });
+}
+
+export default async function CategoryPage({ params }: Props) {
+  const { category } = await params;
+  if (!CATEGORY_LABELS[category]) notFound();
+
+  const { userId } = await auth();
+  const listings = await getListings();
+
+  return (
+    <BrowseClient
+      initialListings={listings}
+      userId={userId ?? null}
+      initialCategory={category}
+    />
+  );
+}

--- a/src/app/browse/actions.ts
+++ b/src/app/browse/actions.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { auth, currentUser } from "@clerk/nextjs/server";
+import { createSavedSearch, deleteSavedSearch } from "@/lib/db/saved-searches";
+
+export async function createSavedSearchAction(
+  category: string | null,
+  maxPriceCents: number | null
+): Promise<{ error?: string; success?: boolean }> {
+  const { userId } = await auth();
+  if (!userId) return { error: "Sign in to save searches." };
+
+  const clerkUser = await currentUser();
+  const email = clerkUser?.emailAddresses?.[0]?.emailAddress;
+  if (!email) return { error: "Could not determine your email address." };
+
+  const result = await createSavedSearch(userId, email, category, maxPriceCents);
+  if (!result) return { error: "Could not save your search. Please try again." };
+  return { success: true };
+}
+
+export async function deleteSavedSearchAction(
+  id: string
+): Promise<{ error?: string; success?: boolean }> {
+  const { userId } = await auth();
+  if (!userId) return { error: "Not authenticated." };
+
+  const ok = await deleteSavedSearch(userId, id);
+  if (!ok) return { error: "Could not delete saved search." };
+  return { success: true };
+}

--- a/src/app/browse/browse-client.tsx
+++ b/src/app/browse/browse-client.tsx
@@ -6,23 +6,28 @@ import { ListingGrid } from "@/components/listing/listing-grid";
 import { ListingFilters } from "@/components/listing/listing-filters";
 import { PageHeader } from "@/components/shared/page-header";
 import { CATEGORY_LABELS } from "@/lib/constants";
-import { X, SlidersHorizontal } from "lucide-react";
+import { X, SlidersHorizontal, Bell, BellRing } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
+import { createSavedSearchAction } from "./actions";
 
 interface BrowseClientProps {
   initialListings: Listing[];
+  userId: string | null;
+  initialCategory?: string;
 }
 
-export function BrowseClient({ initialListings }: BrowseClientProps) {
+export function BrowseClient({ initialListings, userId, initialCategory }: BrowseClientProps) {
   const reduceMotion = useReducedMotion();
   const [search, setSearch] = useState("");
-  const [category, setCategory] = useState("");
+  const [category, setCategory] = useState(initialCategory ?? "");
   const [verifiedOnly, setVerifiedOnly] = useState(false);
   const [sortBy, setSortBy] = useState("newest");
   const [minPrice, setMinPrice] = useState("");
   const [maxPrice, setMaxPrice] = useState("");
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
+  const [alertSaved, setAlertSaved] = useState(false);
+  const [alertSaving, setAlertSaving] = useState(false);
 
   const filtered = useMemo(() => {
     let result = [...initialListings];
@@ -44,7 +49,10 @@ export function BrowseClient({ initialListings }: BrowseClientProps) {
       case "revenue": result.sort((a, b) => b.metrics.mrr - a.metrics.mrr); break;
       default: result.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
     }
-    return result;
+    // Featured listings always appear first
+    const featured = result.filter((l) => l.featured);
+    const rest = result.filter((l) => !l.featured);
+    return [...featured, ...rest];
   }, [initialListings, search, category, verifiedOnly, sortBy, minPrice, maxPrice]);
 
   const activeFilters = [
@@ -62,6 +70,21 @@ export function BrowseClient({ initialListings }: BrowseClientProps) {
     setMinPrice("");
     setMaxPrice("");
     setSortBy("newest");
+    setAlertSaved(false);
+  };
+
+  const handleSaveSearch = async () => {
+    if (!userId) {
+      alert("Sign in to save search alerts.");
+      return;
+    }
+    if (alertSaved || alertSaving) return;
+    setAlertSaving(true);
+    const maxPriceCents = maxPrice ? Math.round(Number(maxPrice) * 100) : null;
+    const result = await createSavedSearchAction(category || null, maxPriceCents);
+    setAlertSaving(false);
+    if (result.error) { alert(result.error); return; }
+    setAlertSaved(true);
   };
 
   const filtersProps = {
@@ -75,7 +98,24 @@ export function BrowseClient({ initialListings }: BrowseClientProps) {
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-      <PageHeader title="Browse Projects" description={`${filtered.length} project${filtered.length !== 1 ? "s" : ""} available`} />
+      <div className="flex items-start justify-between gap-4">
+        <PageHeader title="Browse Projects" description={`${filtered.length} project${filtered.length !== 1 ? "s" : ""} available`} />
+        {(category || maxPrice) && (
+          <button
+            onClick={handleSaveSearch}
+            disabled={alertSaving}
+            className={`mt-1 shrink-0 inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs font-medium transition-colors
+              ${alertSaved
+                ? "border-indigo-500/40 bg-indigo-500/10 text-indigo-300"
+                : "border-zinc-700 bg-zinc-900 text-zinc-400 hover:border-indigo-500/40 hover:text-indigo-300"
+              }`}
+            title={alertSaved ? "Alert saved" : "Save this search for daily alerts"}
+          >
+            {alertSaved ? <BellRing className="h-3.5 w-3.5" /> : <Bell className="h-3.5 w-3.5" />}
+            {alertSaved ? "Alert saved" : "Save search"}
+          </button>
+        )}
+      </div>
 
       <div className="mb-4 lg:hidden">
         <Button variant="outline" size="sm" className="border-zinc-700 text-zinc-300" onClick={() => setMobileFiltersOpen((o) => !o)}>

--- a/src/app/browse/page.tsx
+++ b/src/app/browse/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { auth } from "@clerk/nextjs/server";
 import { getListings } from "@/lib/db/listings";
 import { BrowseClient } from "./browse-client";
 import { publicPageMetadata } from "@/lib/seo";
@@ -10,6 +11,7 @@ export const metadata: Metadata = publicPageMetadata({
 });
 
 export default async function BrowsePage() {
+  const { userId } = await auth();
   const listings = await getListings();
-  return <BrowseClient initialListings={listings} />;
+  return <BrowseClient initialListings={listings} userId={userId ?? null} />;
 }

--- a/src/app/connects/actions.ts
+++ b/src/app/connects/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { auth } from "@clerk/nextjs/server";
+import { clerkClient } from "@clerk/nextjs/server";
 import {
   claimSignupGift,
   ConnectsTransaction,
@@ -11,6 +12,33 @@ import {
 } from "@/lib/db/connects";
 import { getListingById } from "@/lib/db/listings";
 import { revalidatePath } from "next/cache";
+import { absoluteUrl } from "@/lib/seo";
+
+async function notifySellerOfUnlock(sellerId: string, listingTitle: string): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  const fromEmail = process.env.INTEREST_FROM_EMAIL?.trim() || "SideFlip <onboarding@resend.dev>";
+  if (!apiKey) return;
+
+  try {
+    const client = await clerkClient();
+    const seller = await client.users.getUser(sellerId);
+    const email = seller.emailAddresses.find((e) => e.id === seller.primaryEmailAddressId)?.emailAddress;
+    if (!email) return;
+
+    await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: { "Authorization": `Bearer ${apiKey}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        from: fromEmail,
+        to: [email],
+        subject: `[SideFlip] A buyer is interested in "${listingTitle}"`,
+        text: `Great news! A buyer just unlocked your listing "${listingTitle}" on SideFlip.\n\nThey can now see your contact details and will reach out if they want to move forward.\n\nView your listing analytics: ${absoluteUrl("/dashboard")}\n\n— The SideFlip Team`,
+      }),
+    });
+  } catch {
+    // Non-critical — don't let notification failure break the unlock
+  }
+}
 
 export async function giftConnectsAction(): Promise<{
   error?: string;
@@ -44,6 +72,8 @@ export async function unlockListingAction(listingId: string): Promise<{ error?: 
   if (!result.error) {
     revalidatePath(`/listing/${listingId}`);
     revalidatePath("/connects");
+    // Fire-and-forget seller notification
+    notifySellerOfUnlock(listing.sellerId, listing.title).catch(() => null);
   }
   return result;
 }

--- a/src/app/contact/actions.ts
+++ b/src/app/contact/actions.ts
@@ -1,0 +1,41 @@
+"use server";
+
+interface ContactPayload {
+  name: string;
+  email: string;
+  message: string;
+}
+
+export async function sendContactMessageAction(
+  payload: ContactPayload
+): Promise<{ error?: string; success?: boolean }> {
+  const { name, email, message } = payload;
+  if (!name.trim() || !email.trim() || !message.trim()) {
+    return { error: "All fields are required." };
+  }
+
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  const toEmail = process.env.INTEREST_NOTIFY_EMAIL?.trim() || "sudnas11@gmail.com";
+  const fromEmail = process.env.INTEREST_FROM_EMAIL?.trim() || "SideFlip <onboarding@resend.dev>";
+
+  if (!apiKey) {
+    // Dev mode: just log
+    console.info("[contact] message received", { name, email, message });
+    return { success: true };
+  }
+
+  const res = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: { "Authorization": `Bearer ${apiKey}`, "Content-Type": "application/json" },
+    body: JSON.stringify({
+      from: fromEmail,
+      to: [toEmail],
+      reply_to: email,
+      subject: `[SideFlip Contact] ${name}`,
+      text: `From: ${name} <${email}>\n\n${message}`,
+    }),
+  });
+
+  if (!res.ok) return { error: "Could not send message right now." };
+  return { success: true };
+}

--- a/src/app/contact/contact-form.tsx
+++ b/src/app/contact/contact-form.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { sendContactMessageAction } from "./actions";
+
+export function ContactForm() {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [message, setMessage] = useState("");
+  const [status, setStatus] = useState<"idle" | "sending" | "sent" | "error">("idle");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !email.trim() || !message.trim()) return;
+    setStatus("sending");
+    const result = await sendContactMessageAction({ name, email, message });
+    setStatus(result.error ? "error" : "sent");
+  };
+
+  if (status === "sent") {
+    return (
+      <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-6 py-8 text-center">
+        <p className="font-semibold text-emerald-300">Message sent!</p>
+        <p className="mt-1 text-sm text-zinc-400">We&apos;ll get back to you within 24 hours.</p>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-zinc-300 mb-1">Name</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          required
+          className="w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-50 placeholder-zinc-600 focus:border-indigo-500 focus:outline-none"
+          placeholder="Your name"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-zinc-300 mb-1">Email</label>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          className="w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-50 placeholder-zinc-600 focus:border-indigo-500 focus:outline-none"
+          placeholder="you@example.com"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-zinc-300 mb-1">Message</label>
+        <textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          required
+          rows={5}
+          className="w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm text-zinc-50 placeholder-zinc-600 focus:border-indigo-500 focus:outline-none resize-none"
+          placeholder="How can we help?"
+        />
+      </div>
+      {status === "error" && (
+        <p className="text-sm text-red-400">Something went wrong. Please email us directly.</p>
+      )}
+      <Button
+        type="submit"
+        disabled={status === "sending"}
+        className="w-full bg-indigo-600 hover:bg-indigo-500"
+      >
+        {status === "sending" ? "Sending…" : "Send message"}
+      </Button>
+    </form>
+  );
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,46 @@
+import type { Metadata } from "next";
+import { publicPageMetadata } from "@/lib/seo";
+import { ContactForm } from "./contact-form";
+
+export const metadata: Metadata = publicPageMetadata({
+  title: "Contact Us",
+  description: "Get in touch with the SideFlip team for support, questions, or feedback.",
+  path: "/contact",
+});
+
+export default function ContactPage() {
+  return (
+    <div className="mx-auto max-w-2xl px-4 py-12 sm:px-6 lg:px-8">
+      <h1 className="text-3xl font-bold text-zinc-50">Contact Us</h1>
+      <p className="mt-2 text-zinc-400">
+        Have a question, need help, or want to report an issue? We&apos;ll get back to you within 24 hours.
+      </p>
+
+      <div className="mt-10 grid gap-8 sm:grid-cols-[1fr_200px]">
+        <ContactForm />
+
+        <div className="space-y-6 text-sm text-zinc-400">
+          <div>
+            <p className="font-medium text-zinc-300 mb-1">Email</p>
+            <a href="mailto:sudnas11@gmail.com" className="text-indigo-400 hover:text-indigo-300">
+              sudnas11@gmail.com
+            </a>
+          </div>
+          <div>
+            <p className="font-medium text-zinc-300 mb-1">Response time</p>
+            <p>Within 24 hours on weekdays</p>
+          </div>
+          <div>
+            <p className="font-medium text-zinc-300 mb-1">Common topics</p>
+            <ul className="space-y-1 text-zinc-500">
+              <li>Listing verification</li>
+              <li>Connects &amp; billing</li>
+              <li>Account issues</li>
+              <li>Report a listing</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -1,8 +1,10 @@
 "use server";
 
 import { auth } from "@clerk/nextjs/server";
-import { deleteListing, updateListingStatus } from "@/lib/db/listings";
+import { deleteListing, updateListingStatus, featureListing } from "@/lib/db/listings";
 import { deleteDraftBetaTest } from "@/lib/db/beta-tests";
+import { deleteSavedSearch } from "@/lib/db/saved-searches";
+import { updateOfferStatus } from "@/lib/db/offers";
 import { revalidatePath } from "next/cache";
 
 export async function deleteListingAction(
@@ -23,6 +25,70 @@ export async function markSoldAction(
   if (!userId) return { error: "Not authenticated" };
   const ok = await updateListingStatus(userId, listingId, "sold");
   if (!ok) return { error: "Failed to update listing" };
+  revalidatePath("/dashboard");
+  revalidatePath("/browse");
+  return { success: true };
+}
+
+export async function markUnderOfferAction(
+  listingId: string
+): Promise<{ error?: string; success?: boolean }> {
+  const { userId } = await auth();
+  if (!userId) return { error: "Not authenticated" };
+  const ok = await updateListingStatus(userId, listingId, "under_offer");
+  if (!ok) return { error: "Failed to update listing" };
+  revalidatePath("/dashboard");
+  revalidatePath("/browse");
+  revalidatePath(`/listing/${listingId}`);
+  return { success: true };
+}
+
+export async function markActiveAction(
+  listingId: string
+): Promise<{ error?: string; success?: boolean }> {
+  const { userId } = await auth();
+  if (!userId) return { error: "Not authenticated" };
+  const ok = await updateListingStatus(userId, listingId, "active");
+  if (!ok) return { error: "Failed to update listing" };
+  revalidatePath("/dashboard");
+  revalidatePath("/browse");
+  revalidatePath(`/listing/${listingId}`);
+  return { success: true };
+}
+
+export async function boostListingAction(
+  listingId: string,
+  durationDays: 7 | 14 | 30
+): Promise<{ error?: string; success?: boolean }> {
+  const { userId } = await auth();
+  if (!userId) return { error: "Not authenticated" };
+  const result = await featureListing(userId, listingId, durationDays);
+  if (result.error) return { error: result.error };
+  revalidatePath("/dashboard");
+  revalidatePath("/browse");
+  revalidatePath(`/listing/${listingId}`);
+  return { success: true };
+}
+
+export async function deleteSavedSearchAction(
+  id: string
+): Promise<{ error?: string; success?: boolean }> {
+  const { userId } = await auth();
+  if (!userId) return { error: "Not authenticated" };
+  const ok = await deleteSavedSearch(userId, id);
+  if (!ok) return { error: "Could not delete saved search." };
+  revalidatePath("/dashboard");
+  return { success: true };
+}
+
+export async function respondToOfferAction(
+  offerId: string,
+  status: "accepted" | "rejected"
+): Promise<{ error?: string; success?: boolean }> {
+  const { userId } = await auth();
+  if (!userId) return { error: "Not authenticated" };
+  const ok = await updateOfferStatus(userId, offerId, status);
+  if (!ok) return { error: "Failed to update offer." };
   revalidatePath("/dashboard");
   return { success: true };
 }

--- a/src/app/dashboard/dashboard-client.tsx
+++ b/src/app/dashboard/dashboard-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useCallback } from "react";
 import { Listing } from "@/types/listing";
 import { BetaTest } from "@/types/beta-test";
 import { StatCard } from "@/components/shared/stat-card";
@@ -21,12 +21,32 @@ import {
   Loader2,
   CalendarDays,
   ArrowUpRight,
+  Unlock,
+  Handshake,
+  RotateCcw,
+  Star,
+  Zap,
+  Bell,
+  X,
+  Check,
+  CircleX,
 } from "lucide-react";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { formatPrice } from "@/lib/data";
-import { deleteDraftBetaTestAction, deleteListingAction, markSoldAction } from "./actions";
+import { formatPrice, getTesterScore, getListingCompleteness } from "@/lib/data";
+import { SavedSearch } from "@/lib/db/saved-searches";
+import { OfferWithListing } from "@/lib/db/offers";
+import {
+  deleteDraftBetaTestAction,
+  deleteListingAction,
+  markSoldAction,
+  markUnderOfferAction,
+  markActiveAction,
+  boostListingAction,
+  deleteSavedSearchAction,
+  respondToOfferAction,
+} from "./actions";
 
 const MONTHLY_DATA = [
   { month: "Mar", value: 22, label: "$22K" }, { month: "Apr", value: 35, label: "$35K" },
@@ -59,11 +79,16 @@ interface ApplicationRow {
 interface Props {
   displayName: string;
   isAdmin: boolean;
-  stats: { totalEarnings: string; activeListings: number; betaTests: number; feedbackGiven: number };
+  stats: { totalEarnings: string; activeListings: number; betaTests: number; feedbackGiven: number; betaTestsCompleted: number };
   listings: Listing[];
   betaTests: BetaTest[];
   unlockedListings: Listing[];
   myApplications: ApplicationRow[];
+  listingAnalytics: Record<string, { views: number; unlocks: number }>;
+  connectsBalance: number;
+  savedSearches: SavedSearch[];
+  receivedOffers: OfferWithListing[];
+  myOffers: OfferWithListing[];
 }
 
 export function DashboardClient({
@@ -74,6 +99,11 @@ export function DashboardClient({
   betaTests,
   unlockedListings,
   myApplications,
+  listingAnalytics,
+  connectsBalance,
+  savedSearches,
+  receivedOffers,
+  myOffers,
 }: Props) {
   const [activeTab, setActiveTab] = useState("Overview");
   const [betaSubTab, setBetaSubTab] = useState<"posted" | "applied">("posted");
@@ -81,6 +111,23 @@ export function DashboardClient({
   const [myListings, setMyListings] = useState(listings);
   const [myBetaTests, setMyBetaTests] = useState(betaTests);
   const [deletingDraftId, setDeletingDraftId] = useState<string | null>(null);
+  const [boostingListingId, setBoostingListingId] = useState<string | null>(null);
+  const [mySavedSearches, setMySavedSearches] = useState(savedSearches);
+  const [balance, setBalance] = useState(connectsBalance);
+  const [myReceivedOffers, setMyReceivedOffers] = useState(receivedOffers);
+  const mySubmittedOffers = myOffers;
+
+  const testerScore = getTesterScore({ betaTestsCompleted: stats.betaTestsCompleted, feedbackGiven: stats.feedbackGiven });
+
+  const [onboardingDismissed, setOnboardingDismissed] = useState(() => {
+    if (typeof window === "undefined") return true;
+    return localStorage.getItem("sideflip:onboarding-dismissed") === "1";
+  });
+  const dismissOnboarding = () => {
+    localStorage.setItem("sideflip:onboarding-dismissed", "1");
+    setOnboardingDismissed(true);
+  };
+  const showOnboarding = !onboardingDismissed && listings.length === 0 && betaTests.length === 0;
 
   const handleDelete = async (listingId: string) => {
     if (!window.confirm("Delete this listing? This cannot be undone.")) return;
@@ -92,6 +139,42 @@ export function DashboardClient({
     if (!window.confirm("Mark this listing as sold?")) return;
     const result = await markSoldAction(listingId);
     if (!result.error) setMyListings((prev) => prev.map((l) => l.id === listingId ? { ...l, status: "sold" as const } : l));
+  };
+
+  const handleMarkUnderOffer = async (listingId: string) => {
+    if (!window.confirm("Mark this listing as under offer?")) return;
+    const result = await markUnderOfferAction(listingId);
+    if (!result.error) setMyListings((prev) => prev.map((l) => l.id === listingId ? { ...l, status: "under_offer" as const } : l));
+  };
+
+  const handleMarkActive = async (listingId: string) => {
+    if (!window.confirm("Mark this listing as active again?")) return;
+    const result = await markActiveAction(listingId);
+    if (!result.error) setMyListings((prev) => prev.map((l) => l.id === listingId ? { ...l, status: "active" as const } : l));
+  };
+
+  const handleBoost = useCallback(async (listingId: string, durationDays: 7 | 14 | 30) => {
+    setBoostingListingId(listingId);
+    const result = await boostListingAction(listingId, durationDays);
+    setBoostingListingId(null);
+    if (result.error) { window.alert(result.error); return; }
+    const featuredUntil = new Date(Date.now() + durationDays * 24 * 60 * 60 * 1000).toISOString();
+    setMyListings((prev) => prev.map((l) => l.id === listingId ? { ...l, featured: true, featuredUntil } : l));
+    const COSTS: Record<number, number> = { 7: 5, 14: 8, 30: 15 };
+    setBalance((b) => b - (COSTS[durationDays] ?? 0));
+  }, []);
+
+  const handleDeleteSavedSearch = async (id: string) => {
+    const result = await deleteSavedSearchAction(id);
+    if (!result.error) setMySavedSearches((prev) => prev.filter((s) => s.id !== id));
+  };
+
+  const handleRespondToOffer = async (offerId: string, status: "accepted" | "rejected") => {
+    const result = await respondToOfferAction(offerId, status);
+    if (result.error) { window.alert(result.error); return; }
+    setMyReceivedOffers((prev) =>
+      prev.map((o) => (o.id === offerId ? { ...o, status } : o))
+    );
   };
 
   const handleDeleteDraftBetaTest = async (betaTestId: string) => {
@@ -170,7 +253,36 @@ export function DashboardClient({
 
       {activeTab === "Overview" && (
         <div>
-          <div className="grid grid-cols-2 gap-4 sm:grid-cols-4 mb-8">
+          {showOnboarding && (
+            <div className="mb-8 rounded-lg border border-indigo-500/30 bg-indigo-500/5 p-5">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="font-semibold text-zinc-50">Welcome to SideFlip! 🚀</p>
+                  <p className="mt-0.5 text-sm text-zinc-400">Get started in 3 steps to reach buyers.</p>
+                </div>
+                <button onClick={dismissOnboarding} className="text-zinc-600 hover:text-zinc-400 mt-0.5">
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+              <div className="mt-4 grid gap-3 sm:grid-cols-3">
+                {[
+                  { step: "1", label: "Create a listing", desc: "List your side project with metrics and assets.", href: "/create", cta: "Create listing" },
+                  { step: "2", label: "Verify ownership", desc: "Verified listings get 3× more unlocks from buyers.", href: null, cta: null },
+                  { step: "3", label: "Boost your listing", desc: "Use Connects to feature your listing at the top of browse.", href: "/connects", cta: "Get Connects" },
+                ].map((s) => (
+                  <div key={s.step} className="rounded-lg border border-zinc-800 bg-zinc-900 p-3">
+                    <span className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-indigo-600 text-[10px] font-bold text-white">{s.step}</span>
+                    <p className="mt-2 font-medium text-zinc-200 text-sm">{s.label}</p>
+                    <p className="mt-0.5 text-xs text-zinc-500">{s.desc}</p>
+                    {s.href && (
+                      <Link href={s.href} className="mt-2 inline-block text-xs text-indigo-400 hover:text-indigo-300">{s.cta} →</Link>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          <div className="grid grid-cols-2 gap-4 sm:grid-cols-5 mb-8">
             <StatCard label="Total Earnings" value={stats.totalEarnings} icon={<DollarSign className="h-4 w-4" />} />
             <StatCard
               label="Active Listings"
@@ -180,6 +292,12 @@ export function DashboardClient({
             />
             <StatCard label="Beta Tests" value={String(myBetaTests.length)} icon={<TestTube className="h-4 w-4" />} />
             <StatCard label="Feedback Given" value={String(stats.feedbackGiven)} icon={<MessageSquare className="h-4 w-4" />} />
+            <StatCard
+              label="Tester Score"
+              value={testerScore.tier !== "none" ? `${testerScore.score}/100` : "—"}
+              secondaryValue={testerScore.tier !== "none" ? testerScore.label : undefined}
+              icon={<Star className="h-4 w-4" />}
+            />
           </div>
           <h3 className="text-lg font-semibold text-zinc-50 mb-4">Recent Activity</h3>
           <div className="space-y-2">
@@ -209,18 +327,22 @@ export function DashboardClient({
                 <div key={listing.id} className="flex items-center gap-4 rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-3">
                   <div className="flex-1 min-w-0">
                     <p className="font-medium text-zinc-200 truncate">{listing.title}</p>
-                    <div className="flex items-center gap-2 mt-0.5">
+                    <div className="flex items-center gap-2 mt-0.5 flex-wrap">
                       <span className="text-sm text-zinc-400">{formatPrice(listing.askingPrice)}</span>
                       <Badge className={
                         listing.status === "active"
                           ? "bg-green-500/10 text-green-400 border-green-500/20"
                           : listing.status === "sold"
                             ? "bg-zinc-500/10 text-zinc-400 border-zinc-500/20"
-                            : listing.status === "pending_verification"
-                              ? "bg-indigo-500/10 text-indigo-300 border-indigo-500/20"
-                              : "bg-amber-500/10 text-amber-400 border-amber-500/20"
+                            : listing.status === "under_offer"
+                              ? "bg-violet-500/10 text-violet-300 border-violet-500/20"
+                              : listing.status === "pending_verification"
+                                ? "bg-indigo-500/10 text-indigo-300 border-indigo-500/20"
+                                : "bg-amber-500/10 text-amber-400 border-amber-500/20"
                       }>
-                        {listing.status === "pending_verification" ? "pending verification" : listing.status}
+                        {listing.status === "pending_verification" ? "pending verification"
+                          : listing.status === "under_offer" ? "under offer"
+                          : listing.status}
                       </Badge>
                       {listing.ownershipVerified && (
                         <Badge className="bg-emerald-500/10 text-emerald-300 border-emerald-500/20">
@@ -232,6 +354,26 @@ export function DashboardClient({
                         </Badge>
                       )}
                     </div>
+                    {(listingAnalytics[listing.id]?.views > 0 || listingAnalytics[listing.id]?.unlocks > 0) && (
+                      <div className="flex items-center gap-3 mt-1 text-xs text-zinc-500">
+                        <span className="flex items-center gap-1">
+                          <Eye className="h-3 w-3" />{listingAnalytics[listing.id]?.views ?? 0} views
+                        </span>
+                        <span className="flex items-center gap-1">
+                          <Unlock className="h-3 w-3" />{listingAnalytics[listing.id]?.unlocks ?? 0} unlocks
+                        </span>
+                      </div>
+                    )}
+                    {(() => {
+                      const { score } = getListingCompleteness(listing);
+                      const color = score >= 80 ? "text-green-400" : score >= 50 ? "text-amber-400" : "text-red-400";
+                      return <span className={`text-xs ${color} mt-0.5 block`}>{score}% complete</span>;
+                    })()}
+                    {listing.featured && listing.featuredUntil && (
+                      <span className="text-xs text-amber-400 mt-0.5 block">
+                        Featured until {new Date(listing.featuredUntil).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                      </span>
+                    )}
                   </div>
                   <div className="flex items-center gap-2 shrink-0">
                     <Link href={`/listing/${listing.id}`}>
@@ -252,9 +394,52 @@ export function DashboardClient({
                       </Link>
                     )}
                     {listing.status === "active" && (
-                      <Button size="sm" variant="outline" className="border-zinc-700 text-amber-400 hover:text-amber-300 px-2" onClick={() => handleMarkSold(listing.id)}>
-                        <CheckCheck className="h-3.5 w-3.5" />
+                      <>
+                        <Button size="sm" variant="outline" className="border-zinc-700 text-violet-400 hover:text-violet-300 px-2" title="Mark as under offer" onClick={() => handleMarkUnderOffer(listing.id)}>
+                          <Handshake className="h-3.5 w-3.5" />
+                        </Button>
+                        <Button size="sm" variant="outline" className="border-zinc-700 text-amber-400 hover:text-amber-300 px-2" title="Mark as sold" onClick={() => handleMarkSold(listing.id)}>
+                          <CheckCheck className="h-3.5 w-3.5" />
+                        </Button>
+                      </>
+                    )}
+                    {listing.status === "under_offer" && (
+                      <Button size="sm" variant="outline" className="border-zinc-700 text-green-400 hover:text-green-300 px-2" title="Re-activate listing" onClick={() => handleMarkActive(listing.id)}>
+                        <RotateCcw className="h-3.5 w-3.5" />
                       </Button>
+                    )}
+                    {!listing.featured && listing.status === "active" && (
+                      boostingListingId === listing.id ? (
+                        <div className="flex items-center gap-1">
+                          {([7, 14, 30] as const).map((d) => {
+                            const costs: Record<number, number> = { 7: 5, 14: 8, 30: 15 };
+                            return (
+                              <button
+                                key={d}
+                                onClick={() => handleBoost(listing.id, d)}
+                                disabled={balance < costs[d]}
+                                className="rounded border border-amber-500/40 bg-amber-500/10 px-2 py-1 text-[10px] font-medium text-amber-300 hover:bg-amber-500/20 disabled:opacity-40"
+                                title={`${d}d — ${costs[d]} connects`}
+                              >
+                                {d}d·{costs[d]}c
+                              </button>
+                            );
+                          })}
+                          <button onClick={() => setBoostingListingId(null)} className="text-zinc-500 hover:text-zinc-300 px-1">
+                            <X className="h-3.5 w-3.5" />
+                          </button>
+                        </div>
+                      ) : (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="border-amber-500/30 text-amber-400 hover:text-amber-300 px-2"
+                          title={`Boost listing (${balance} connects available)`}
+                          onClick={() => setBoostingListingId(listing.id)}
+                        >
+                          <Zap className="h-3.5 w-3.5" />
+                        </Button>
+                      )
                     )}
                     <Button size="sm" variant="outline" className="border-zinc-700 text-red-400 hover:text-red-300 px-2" onClick={() => handleDelete(listing.id)}>
                       <Trash2 className="h-3.5 w-3.5" />
@@ -262,6 +447,56 @@ export function DashboardClient({
                   </div>
                 </div>
               ))}
+            </div>
+          )}
+
+          {myReceivedOffers.length > 0 && (
+            <div className="mt-8">
+              <h3 className="text-lg font-semibold text-zinc-50 mb-4">Received Offers</h3>
+              <div className="space-y-2">
+                {myReceivedOffers.map((offer) => (
+                  <div key={offer.id} className="flex items-center gap-4 rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-3">
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-medium text-zinc-200">{formatPrice(offer.amountCents)}</span>
+                        <Badge className={
+                          offer.status === "accepted"
+                            ? "bg-green-500/10 text-green-400 border-green-500/20"
+                            : offer.status === "rejected"
+                              ? "bg-red-500/10 text-red-400 border-red-500/20"
+                              : "bg-zinc-500/10 text-zinc-400 border-zinc-500/20"
+                        }>
+                          {offer.status}
+                        </Badge>
+                      </div>
+                      <p className="text-xs text-zinc-500 mt-0.5 truncate">
+                        {offer.listingTitle} · {new Date(offer.createdAt).toLocaleDateString()}
+                      </p>
+                      {offer.message && (
+                        <p className="text-xs text-zinc-400 mt-1 line-clamp-2">{offer.message}</p>
+                      )}
+                    </div>
+                    {offer.status === "pending" && (
+                      <div className="flex items-center gap-1 shrink-0">
+                        <button
+                          onClick={() => handleRespondToOffer(offer.id, "accepted")}
+                          className="rounded-md border border-green-500/40 bg-green-500/10 p-1.5 text-green-400 hover:bg-green-500/20"
+                          title="Accept offer"
+                        >
+                          <Check className="h-3.5 w-3.5" />
+                        </button>
+                        <button
+                          onClick={() => handleRespondToOffer(offer.id, "rejected")}
+                          className="rounded-md border border-red-500/40 bg-red-500/10 p-1.5 text-red-400 hover:bg-red-500/20"
+                          title="Reject offer"
+                        >
+                          <CircleX className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
             </div>
           )}
         </div>
@@ -430,6 +665,66 @@ export function DashboardClient({
 
       {activeTab === "As Buyer" && (
         <div className="space-y-8">
+          {mySubmittedOffers.length > 0 && (
+            <div>
+              <h3 className="text-lg font-semibold text-zinc-50 mb-4">My Offers</h3>
+              <div className="space-y-2">
+                {mySubmittedOffers.map((offer) => (
+                  <Link
+                    key={offer.id}
+                    href={`/listing/${offer.listingId}`}
+                    className="group flex items-center gap-4 rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-3 transition-colors hover:border-indigo-500/40"
+                  >
+                    <div className="flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="font-medium text-zinc-200">{formatPrice(offer.amountCents)}</span>
+                        <Badge className={
+                          offer.status === "accepted"
+                            ? "bg-green-500/10 text-green-400 border-green-500/20"
+                            : offer.status === "rejected"
+                              ? "bg-red-500/10 text-red-400 border-red-500/20"
+                              : "bg-zinc-500/10 text-zinc-400 border-zinc-500/20"
+                        }>
+                          {offer.status}
+                        </Badge>
+                      </div>
+                      <p className="text-xs text-zinc-500 mt-0.5 truncate">
+                        {offer.listingTitle} · {new Date(offer.createdAt).toLocaleDateString()}
+                      </p>
+                    </div>
+                    <ArrowUpRight className="h-3.5 w-3.5 text-zinc-500 group-hover:text-indigo-300 shrink-0" />
+                  </Link>
+                ))}
+              </div>
+            </div>
+          )}
+          <div>
+            <h3 className="text-lg font-semibold text-zinc-50 mb-4">Saved Alerts</h3>
+            {mySavedSearches.length === 0 ? (
+              <div className="flex flex-col items-center justify-center py-8 text-center rounded-lg border border-zinc-800 bg-zinc-900">
+                <Bell className="h-8 w-8 text-zinc-700 mb-3" />
+                <p className="font-medium text-zinc-400">No saved alerts</p>
+                <p className="mt-1 text-sm text-zinc-600">Browse listings and click the bell icon to create one.</p>
+                <Link href="/browse" className="mt-4">
+                  <Button size="sm" className="bg-indigo-600 hover:bg-indigo-500">Browse listings</Button>
+                </Link>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                {mySavedSearches.map((s) => (
+                  <div key={s.id} className="flex items-center justify-between rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-3">
+                    <span className="text-sm text-zinc-300">
+                      {s.category ? CATEGORY_LABELS[s.category as Listing["category"]] ?? s.category : "Any category"}
+                      {s.maxPriceCents ? ` · Under $${(s.maxPriceCents / 100).toLocaleString()}` : ""}
+                    </span>
+                    <button onClick={() => handleDeleteSavedSearch(s.id)} className="text-zinc-600 hover:text-red-400 ml-4">
+                      <X className="h-4 w-4" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
           <div>
             <h3 className="text-lg font-semibold text-zinc-50 mb-4">Unlocked Listings</h3>
             {unlockedListings.length === 0 ? (

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,9 @@
 import { auth, currentUser } from "@clerk/nextjs/server";
 import { redirect } from "next/navigation";
-import { getAllListingsBySeller, getUnlockedListings } from "@/lib/db/listings";
+import { getAllListingsBySeller, getUnlockedListings, getListingAnalytics } from "@/lib/db/listings";
+import { getConnectsBalance } from "@/lib/db/connects";
+import { getSavedSearchesByUser } from "@/lib/db/saved-searches";
+import { getOffersForSeller, getOffersForBuyer } from "@/lib/db/offers";
 import { getBetaTestsByCreator } from "@/lib/db/beta-tests";
 import { getProfile } from "@/lib/db/profiles";
 import { formatPrice } from "@/lib/data";
@@ -18,13 +21,19 @@ export default async function DashboardPage() {
 
   const clerkUser = await currentUser();
 
-  const [profile, listings, allBetaTests, unlockedListings, myApplications] = await Promise.all([
+  const [profile, listings, allBetaTests, unlockedListings, myApplications, connectsBalance, savedSearches, receivedOffers, myOffers] = await Promise.all([
     getProfile(userId),
     getAllListingsBySeller(userId),
     getBetaTestsByCreator(userId),
     getUnlockedListings(userId),
     getUserApplications(userId),
+    getConnectsBalance(userId),
+    getSavedSearchesByUser(userId),
+    getOffersForSeller(userId),
+    getOffersForBuyer(userId),
   ]);
+
+  const listingAnalytics = await getListingAnalytics(listings.map((l) => l.id));
 
   const myBetaTests = allBetaTests;
 
@@ -39,6 +48,7 @@ export default async function DashboardPage() {
     activeListings: listings.filter((l) => l.status === "active").length,
     betaTests: myBetaTests.length,
     feedbackGiven: profile?.stats.feedbackGiven ?? 0,
+    betaTestsCompleted: profile?.stats.betaTestsCompleted ?? 0,
   };
 
   return (
@@ -50,6 +60,11 @@ export default async function DashboardPage() {
       betaTests={myBetaTests}
       unlockedListings={unlockedListings}
       myApplications={myApplications}
+      listingAnalytics={listingAnalytics}
+      connectsBalance={connectsBalance}
+      savedSearches={savedSearches}
+      receivedOffers={receivedOffers}
+      myOffers={myOffers}
     />
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Inter, JetBrains_Mono } from "next/font/google";
 import { ClerkProvider } from "@clerk/nextjs";
 import "./globals.css";
-import { Navbar } from "@/components/layout/navbar";
+import { NavbarWrapper } from "@/components/layout/navbar-wrapper";
 import { Footer } from "@/components/layout/footer";
 import { PageTransition } from "@/components/layout/page-transition";
 import { SITE_NAME, SITE_DESCRIPTION } from "@/lib/constants";
@@ -57,7 +57,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <html lang="en" className="dark">
         <body className={`${inter.variable} ${jetbrains.variable} font-sans bg-zinc-950 text-zinc-50 antialiased`}>
           <div className="flex min-h-screen flex-col">
-            <Navbar />
+            <NavbarWrapper />
             <main className="flex-1">
               <PageTransition>{children}</PageTransition>
             </main>

--- a/src/app/listing/[id]/edit/actions.ts
+++ b/src/app/listing/[id]/edit/actions.ts
@@ -43,6 +43,7 @@ export async function updateListingAction(
     monthlyVisitors: number;
     registeredUsers: number;
     assetsIncluded: string[];
+    screenshots: string[];
   }
 ): Promise<{ error?: string; success?: boolean }> {
   const { userId } = await auth();
@@ -100,6 +101,10 @@ export async function updateListingAction(
     .filter(Boolean)
     .slice(0, 50);
 
+  const screenshots = (payload.screenshots ?? [])
+    .filter((u) => typeof u === "string" && u.startsWith("https://"))
+    .slice(0, 10);
+
   const ok = await updateListing(userId, safeListingId, {
     title,
     pitch,
@@ -113,6 +118,7 @@ export async function updateListingAction(
     monthlyVisitors: Math.floor(payload.monthlyVisitors),
     registeredUsers: Math.floor(payload.registeredUsers),
     assetsIncluded,
+    screenshots,
   });
 
   if (!ok) return { error: "Failed to update. You may not have permission." };

--- a/src/app/listing/[id]/edit/edit-form.tsx
+++ b/src/app/listing/[id]/edit/edit-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useRef, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -8,7 +8,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { PageHeader } from "@/components/shared/page-header";
 import { CATEGORY_LABELS } from "@/lib/constants";
-import { CheckCircle, X, Info, Loader2 } from "lucide-react";
+import { CheckCircle, X, Info, Loader2, ImagePlus, Trash2 } from "lucide-react";
 import { Listing } from "@/types/listing";
 import { updateListingAction } from "./actions";
 
@@ -31,6 +31,9 @@ export function EditListingForm({ listing }: { listing: Listing }) {
   const [techInput, setTechInput] = useState("");
   const [techStack, setTechStack] = useState<string[]>(listing.techStack);
   const [assets, setAssets] = useState<string[]>(listing.assetsIncluded);
+  const [screenshots, setScreenshots] = useState<string[]>(listing.screenshots);
+  const [uploadingScreenshot, setUploadingScreenshot] = useState(false);
+  const [screenshotError, setScreenshotError] = useState("");
   // prices stored as dollars in state (DB is in cents)
   const [mrr, setMrr] = useState(String(listing.metrics.mrr / 100));
   const [askingPrice, setAskingPrice] = useState(String(listing.askingPrice / 100));
@@ -44,6 +47,32 @@ export function EditListingForm({ listing }: { listing: Listing }) {
   const removeTech = (tech: string) => setTechStack(techStack.filter((t) => t !== tech));
   const toggleAsset = (id: string) =>
     setAssets((prev) => (prev.includes(id) ? prev.filter((a) => a !== id) : [...prev, id]));
+
+  const handleScreenshotUpload = useCallback(async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    if (screenshots.length + files.length > 10) {
+      setScreenshotError("Maximum 10 screenshots allowed.");
+      return;
+    }
+    setUploadingScreenshot(true);
+    setScreenshotError("");
+    const uploaded: string[] = [];
+    for (const file of Array.from(files)) {
+      const fd = new FormData();
+      fd.append("file", file);
+      try {
+        const res = await fetch("/api/upload/screenshot", { method: "POST", body: fd });
+        const json = await res.json();
+        if (json.error) { setScreenshotError(json.error); break; }
+        if (json.url) uploaded.push(json.url);
+      } catch {
+        setScreenshotError("Upload failed. Please try again.");
+        break;
+      }
+    }
+    setScreenshots((prev) => [...prev, ...uploaded]);
+    setUploadingScreenshot(false);
+  }, [screenshots.length]);
 
   const mrrNum = Number(mrr);
   const priceNum = Number(askingPrice);
@@ -75,6 +104,7 @@ export function EditListingForm({ listing }: { listing: Listing }) {
       monthlyVisitors: Number(fd.get("monthlyVisitors")) || 0,
       registeredUsers: Number(fd.get("registeredUsers")) || 0,
       assetsIncluded: assets,
+      screenshots,
     });
 
     if (result.error) {
@@ -229,6 +259,42 @@ export function EditListingForm({ listing }: { listing: Listing }) {
               </button>
             ))}
           </div>
+        </section>
+
+        <section>
+          <h2 className="text-lg font-semibold text-zinc-50 mb-1">Screenshots</h2>
+          <p className="text-sm text-zinc-500 mb-4">Upload up to 10 images (JPEG, PNG, WebP — max 5MB each).</p>
+          {screenshots.length > 0 && (
+            <div className="mb-3 grid grid-cols-3 gap-2">
+              {screenshots.map((url, i) => (
+                <div key={url} className="relative group aspect-video rounded-lg overflow-hidden border border-zinc-800">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img src={url} alt={`Screenshot ${i + 1}`} className="w-full h-full object-cover" />
+                  <button
+                    type="button"
+                    onClick={() => setScreenshots((prev) => prev.filter((_, idx) => idx !== i))}
+                    className="absolute top-1 right-1 rounded-full bg-zinc-900/80 p-1 opacity-0 group-hover:opacity-100 transition-opacity"
+                  >
+                    <Trash2 className="h-3.5 w-3.5 text-red-400" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+          {screenshotError && <p className="mb-2 text-xs text-red-400">{screenshotError}</p>}
+          {screenshots.length < 10 && (
+            <label className={`flex cursor-pointer items-center gap-2 rounded-lg border border-dashed border-zinc-700 px-4 py-3 text-sm text-zinc-400 hover:border-zinc-500 hover:text-zinc-300 transition-colors ${uploadingScreenshot ? "opacity-50 pointer-events-none" : ""}`}>
+              {uploadingScreenshot ? <Loader2 className="h-4 w-4 animate-spin" /> : <ImagePlus className="h-4 w-4" />}
+              {uploadingScreenshot ? "Uploading..." : "Add screenshot"}
+              <input
+                type="file"
+                accept="image/jpeg,image/png,image/webp,image/gif"
+                multiple
+                className="sr-only"
+                onChange={(e) => handleScreenshotUpload(e.target.files)}
+              />
+            </label>
+          )}
         </section>
 
         <div className="flex gap-3">

--- a/src/app/listing/[id]/offer-actions.ts
+++ b/src/app/listing/[id]/offer-actions.ts
@@ -1,0 +1,83 @@
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { clerkClient } from "@clerk/nextjs/server";
+import { createOffer, updateOfferStatus } from "@/lib/db/offers";
+import { getListingById } from "@/lib/db/listings";
+import { revalidatePath } from "next/cache";
+import { absoluteUrl } from "@/lib/seo";
+
+async function notifySellerOfOffer(
+  sellerId: string,
+  listingTitle: string,
+  amountCents: number
+): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  if (!apiKey) return;
+  const fromEmail = process.env.INTEREST_FROM_EMAIL?.trim() || "SideFlip <onboarding@resend.dev>";
+  try {
+    const client = await clerkClient();
+    const seller = await client.users.getUser(sellerId);
+    const email = seller.emailAddresses.find(
+      (e) => e.id === seller.primaryEmailAddressId
+    )?.emailAddress;
+    if (!email) return;
+    const price = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(
+      amountCents / 100
+    );
+    await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        from: fromEmail,
+        to: [email],
+        subject: `[SideFlip] New offer of ${price} on "${listingTitle}"`,
+        text: `Good news! You received an offer of ${price} for "${listingTitle}" on SideFlip.\n\nLog in to your dashboard to review and respond.\n\n${absoluteUrl("/dashboard")}\n\n— The SideFlip Team`,
+      }),
+    });
+  } catch {
+    // Non-critical
+  }
+}
+
+export async function submitOfferAction(
+  listingId: string,
+  amountCents: number,
+  message: string
+): Promise<{ error?: string; success?: boolean }> {
+  const { userId } = await auth();
+  if (!userId) return { error: "Not authenticated" };
+
+  const listing = await getListingById(listingId);
+  if (!listing) return { error: "Listing not found" };
+  if (!listing.openToOffers) return { error: "This listing is not accepting offers" };
+  if (userId === listing.sellerId) return { error: "You cannot make an offer on your own listing" };
+
+  if (!Number.isInteger(amountCents) || amountCents <= 0) {
+    return { error: "Enter a valid offer amount." };
+  }
+  if (amountCents > 10_000_000 * 100) return { error: "Offer amount is too large." };
+
+  const msg = (message ?? "").trim().slice(0, 500);
+  const result = await createOffer(userId, listingId, amountCents, msg);
+  if (!result) return { error: "Failed to submit offer. Please try again." };
+
+  notifySellerOfOffer(listing.sellerId, listing.title, amountCents).catch(() => null);
+
+  revalidatePath(`/listing/${listingId}`);
+  return { success: true };
+}
+
+export async function respondToOfferAction(
+  offerId: string,
+  status: "accepted" | "rejected"
+): Promise<{ error?: string; success?: boolean }> {
+  const { userId } = await auth();
+  if (!userId) return { error: "Not authenticated" };
+
+  const ok = await updateOfferStatus(userId, offerId, status);
+  if (!ok) return { error: "Failed to update offer. Please try again." };
+
+  revalidatePath("/dashboard");
+  return { success: true };
+}

--- a/src/app/listing/[id]/offer-section.tsx
+++ b/src/app/listing/[id]/offer-section.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { submitOfferAction } from "./offer-actions";
+import { CheckCircle, DollarSign, Loader2 } from "lucide-react";
+
+interface OfferSectionProps {
+  listingId: string;
+  askingPriceCents: number;
+  userId: string | null;
+}
+
+export function OfferSection({ listingId, askingPriceCents, userId }: OfferSectionProps) {
+  const [showForm, setShowForm] = useState(false);
+  const [amount, setAmount] = useState("");
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  if (success) {
+    return (
+      <div className="mt-4 flex items-start gap-2 rounded-lg border border-green-500/20 bg-green-500/5 p-4">
+        <CheckCircle className="mt-0.5 h-4 w-4 shrink-0 text-green-400" />
+        <p className="text-sm text-green-400">
+          Offer submitted! The seller has been notified. Check your dashboard for updates.
+        </p>
+      </div>
+    );
+  }
+
+  if (!showForm) {
+    return (
+      <div className="mt-4">
+        <Button
+          size="sm"
+          variant="outline"
+          className="w-full border-zinc-700 text-zinc-300 hover:border-indigo-500/50 hover:text-indigo-300"
+          onClick={() => {
+            if (!userId) {
+              alert("Sign in to make an offer");
+              return;
+            }
+            setShowForm(true);
+          }}
+        >
+          <DollarSign className="mr-1.5 h-3.5 w-3.5" />
+          Make an offer
+        </Button>
+      </div>
+    );
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const amountCents = Math.round((Number(amount) || 0) * 100);
+    if (!amountCents || amountCents <= 0) {
+      setError("Enter a valid offer amount.");
+      return;
+    }
+    setLoading(true);
+    setError("");
+    const result = await submitOfferAction(listingId, amountCents, message);
+    if (result.error) {
+      setError(result.error);
+      setLoading(false);
+      return;
+    }
+    setSuccess(true);
+    setLoading(false);
+  };
+
+  const suggestedPrice = Math.round(askingPriceCents / 100 * 0.9);
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mt-4 space-y-3 rounded-lg border border-zinc-700 bg-zinc-800/40 p-4"
+    >
+      <p className="text-sm font-medium text-zinc-300">Make an offer</p>
+      <div>
+        <label className="mb-1 block text-xs text-zinc-500">Your offer (USD)</label>
+        <Input
+          type="number"
+          min="1"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          placeholder={String(suggestedPrice)}
+          className="bg-zinc-900 border-zinc-700 text-sm"
+          required
+        />
+      </div>
+      <div>
+        <label className="mb-1 block text-xs text-zinc-500">Message (optional)</label>
+        <Textarea
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder="Tell the seller about yourself and why you're interested..."
+          className="bg-zinc-900 border-zinc-700 text-sm"
+          rows={3}
+          maxLength={500}
+        />
+      </div>
+      {error && <p className="text-xs text-red-400">{error}</p>}
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="outline"
+          className="border-zinc-700 text-zinc-400"
+          onClick={() => setShowForm(false)}
+        >
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          size="sm"
+          className="flex-1 bg-indigo-600 hover:bg-indigo-500"
+          disabled={loading}
+        >
+          {loading ? (
+            <>
+              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+              Submitting...
+            </>
+          ) : (
+            "Submit Offer"
+          )}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/app/listing/[id]/page.tsx
+++ b/src/app/listing/[id]/page.tsx
@@ -3,7 +3,9 @@ import {
   getListingByIdForSeller,
   getSimilarListings,
   getListingsBySeller,
+  recordListingView,
 } from "@/lib/db/listings";
+import { after } from "next/server";
 import { getProfile } from "@/lib/db/profiles";
 import { getConnectsBalance, isListingUnlocked, getUnlockCost } from "@/lib/db/connects";
 import { getRevenueMultiple, formatPrice, formatNumber } from "@/lib/data";
@@ -13,6 +15,7 @@ import { StatCard } from "@/components/shared/stat-card";
 import { PurchaseCard } from "@/components/listing/purchase-card";
 import { ListingCard } from "@/components/listing/listing-card";
 import { SellerWebsiteGate } from "./seller-section";
+import { OfferSection } from "./offer-section";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { JsonLd } from "@/components/shared/json-ld";
@@ -100,6 +103,11 @@ export default async function ListingDetailPage({ params }: Props) {
 
   const sellerOtherListings = sellerListings.filter((l) => l.id !== listing.id).slice(0, 2);
   const unlockCost = getUnlockCost(listing.askingPrice);
+
+  // Track view — fire after response is sent, skip seller's own views
+  if (!isSeller && (listing.status === "active" || listing.status === "under_offer")) {
+    after(() => recordListingView(listing.id, userId ?? null));
+  }
 
   const TrendIcon = listing.metrics.revenueTrend === "up" ? TrendingUp : listing.metrics.revenueTrend === "down" ? TrendingDown : Minus;
   const trendColor = listing.metrics.revenueTrend === "up" ? "text-green-400" : listing.metrics.revenueTrend === "down" ? "text-red-400" : "text-zinc-400";
@@ -214,6 +222,14 @@ export default async function ListingDetailPage({ params }: Props) {
             )}
           </div>
 
+          {listing.status === "under_offer" && !isSeller && (
+            <div className="mb-6 rounded-lg border border-violet-500/30 bg-violet-500/10 p-4">
+              <p className="text-sm text-violet-300">
+                This listing is currently under offer. You can still unlock and contact the seller — deals aren&apos;t final until both parties agree.
+              </p>
+            </div>
+          )}
+
           {isSeller && listing.status === "pending_verification" && (
             <div className="mb-6 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
               <p className="text-sm text-amber-300">
@@ -229,12 +245,19 @@ export default async function ListingDetailPage({ params }: Props) {
             </div>
           )}
 
-          <div className="mb-8 flex h-64 flex-col items-center justify-center rounded-lg border border-zinc-800 bg-gradient-to-br from-zinc-900 to-zinc-800">
-            <span className="text-4xl font-black tracking-wider text-zinc-700">
-              {listing.title.split(" ").map((w) => w[0]).join("").slice(0, 3)}
-            </span>
-            <span className="mt-2 text-xs text-zinc-600">Screenshots coming soon</span>
-          </div>
+          {listing.screenshots.length > 0 && (
+            <div className="mb-8 grid grid-cols-2 gap-3 sm:grid-cols-3">
+              {listing.screenshots.map((url, i) => (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  key={i}
+                  src={url}
+                  alt={`${listing.title} screenshot ${i + 1}`}
+                  className="aspect-video w-full rounded-lg border border-zinc-800 object-cover"
+                />
+              ))}
+            </div>
+          )}
 
           <div className="mb-8">{renderDescription(listing.description)}</div>
 
@@ -350,19 +373,28 @@ export default async function ListingDetailPage({ params }: Props) {
               </Link>
             </div>
           ) : (
-            <PurchaseCard
-              askingPrice={formatPrice(listing.askingPrice)}
-              openToOffers={listing.openToOffers}
-              age={listing.metrics.age}
-              revenueTrend={listing.metrics.revenueTrend}
-              revenueMultiple={revenueMultiple}
-              mrr={formatPrice(listing.metrics.mrr)}
-              listingId={listing.id}
-              isUnlocked={unlocked}
-              userId={userId ?? null}
-              connectsBalance={connectsBalance}
-              unlockCost={unlockCost}
-            />
+            <>
+              <PurchaseCard
+                askingPrice={formatPrice(listing.askingPrice)}
+                openToOffers={listing.openToOffers}
+                age={listing.metrics.age}
+                revenueTrend={listing.metrics.revenueTrend}
+                revenueMultiple={revenueMultiple}
+                mrr={formatPrice(listing.metrics.mrr)}
+                listingId={listing.id}
+                isUnlocked={unlocked}
+                userId={userId ?? null}
+                connectsBalance={connectsBalance}
+                unlockCost={unlockCost}
+              />
+              {listing.openToOffers && !isSeller && (
+                <OfferSection
+                  listingId={listing.id}
+                  askingPriceCents={listing.askingPrice}
+                  userId={userId ?? null}
+                />
+              )}
+            </>
           )}
         </div>
       </div>

--- a/src/app/seller/[id]/page.tsx
+++ b/src/app/seller/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { getProfile } from "@/lib/db/profiles";
 import { getListingsBySeller } from "@/lib/db/listings";
 import { getBetaTests } from "@/lib/db/beta-tests";
-import { formatPrice } from "@/lib/data";
+import { formatPrice, getTesterScore } from "@/lib/data";
 import { ListingCard } from "@/components/listing/listing-card";
 import { Badge } from "@/components/ui/badge";
 import { StatCard } from "@/components/shared/stat-card";
@@ -41,6 +41,7 @@ export default async function SellerPage({ params }: Props) {
   if (!seller) notFound();
 
   const activeBetaTests = allBetaTests.filter((bt) => bt.creatorId === id && bt.status !== "closed");
+  const testerScore = getTesterScore({ betaTestsCompleted: seller.stats.betaTestsCompleted ?? 0, feedbackGiven: seller.stats.feedbackGiven ?? 0 });
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
@@ -73,6 +74,19 @@ export default async function SellerPage({ params }: Props) {
             <div className="border-t border-zinc-800 pt-4 text-xs text-zinc-500 text-center">
               Member since {new Date(seller.stats.memberSince).toLocaleDateString("en-US", { month: "long", year: "numeric" })}
             </div>
+            {testerScore.tier !== "none" && (
+              <div className="mt-3 flex justify-center">
+                <span className={`inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold border ${
+                  testerScore.tier === "gold"
+                    ? "bg-amber-500/15 border-amber-500/30 text-amber-300"
+                    : testerScore.tier === "silver"
+                      ? "bg-zinc-400/15 border-zinc-400/30 text-zinc-300"
+                      : "bg-orange-700/15 border-orange-700/30 text-orange-400"
+                }`}>
+                  ⭐ {testerScore.label} · {testerScore.score}/100
+                </span>
+              </div>
+            )}
           </div>
         </aside>
 

--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -41,6 +41,7 @@ export function Footer() {
               <li><Link href="/terms" className="text-sm text-zinc-400 hover:text-zinc-50">Terms of Service</Link></li>
               <li><Link href="/privacy" className="text-sm text-zinc-400 hover:text-zinc-50">Privacy Policy</Link></li>
               <li><Link href="/refund" className="text-sm text-zinc-400 hover:text-zinc-50">Refund Policy</Link></li>
+              <li><Link href="/contact" className="text-sm text-zinc-400 hover:text-zinc-50">Contact Us</Link></li>
             </ul>
           </div>
         </div>

--- a/src/components/layout/navbar-wrapper.tsx
+++ b/src/components/layout/navbar-wrapper.tsx
@@ -1,0 +1,9 @@
+import { auth } from "@clerk/nextjs/server";
+import { getConnectsBalance } from "@/lib/db/connects";
+import { Navbar } from "./navbar";
+
+export async function NavbarWrapper() {
+  const { userId } = await auth();
+  const connectsBalance = userId ? await getConnectsBalance(userId) : null;
+  return <Navbar connectsBalance={connectsBalance} />;
+}

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { Menu, X, Rocket } from "lucide-react";
+import { Menu, X, Rocket, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { NAV_LINKS, SITE_NAME } from "@/lib/constants";
 import { AnimatePresence, motion } from "framer-motion";
@@ -15,7 +15,11 @@ import {
   UserButton,
 } from "@clerk/nextjs";
 
-export function Navbar() {
+interface NavbarProps {
+  connectsBalance?: number | null;
+}
+
+export function Navbar({ connectsBalance }: NavbarProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
   const pathname = usePathname();
 
@@ -86,6 +90,16 @@ export function Navbar() {
                 )}
               </Link>
             ))}
+            {connectsBalance != null && (
+              <Link
+                href="/connects"
+                className="inline-flex items-center gap-1 rounded-full border border-indigo-500/30 bg-indigo-500/10 px-2.5 py-1 text-xs font-medium text-indigo-300 hover:bg-indigo-500/20 transition-colors"
+                title="Your Connects balance"
+              >
+                <Zap className="h-3 w-3" />
+                {connectsBalance}
+              </Link>
+            )}
             <UserButton appearance={{ elements: { avatarBox: "h-8 w-8" } }} />
           </SignedIn>
         </div>
@@ -179,6 +193,16 @@ export function Navbar() {
                 <div className="flex items-center gap-3 py-2">
                   <UserButton />
                   <span className="text-sm text-zinc-400">My Account</span>
+                  {connectsBalance != null && (
+                    <Link
+                      href="/connects"
+                      className="ml-auto inline-flex items-center gap-1 rounded-full border border-indigo-500/30 bg-indigo-500/10 px-2.5 py-1 text-xs font-medium text-indigo-300"
+                      onClick={() => setMobileOpen(false)}
+                    >
+                      <Zap className="h-3 w-3" />
+                      {connectsBalance}
+                    </Link>
+                  )}
                 </div>
               </SignedIn>
             </div>

--- a/src/components/listing/listing-card.tsx
+++ b/src/components/listing/listing-card.tsx
@@ -96,9 +96,19 @@ export function ListingCard({ listing }: ListingCardProps) {
               {CATEGORY_LABELS[listing.category]}
             </Badge>
 
-            {/* New / Hot badges */}
+            {/* Featured / New / Hot / Under Offer badges */}
             <div className="absolute top-2 right-2 flex flex-col gap-1">
-              {isNew && (
+              {listing.featured && (
+                <span className="inline-flex items-center gap-0.5 rounded-full bg-amber-500/15 border border-amber-500/30 px-1.5 py-0.5 text-[10px] font-semibold text-amber-300">
+                  ⭐ Featured
+                </span>
+              )}
+              {listing.status === "under_offer" && (
+                <span className="inline-flex items-center gap-0.5 rounded-full bg-violet-500/15 border border-violet-500/30 px-1.5 py-0.5 text-[10px] font-semibold text-violet-300">
+                  Under Offer
+                </span>
+              )}
+              {isNew && listing.status !== "under_offer" && (
                 <span className="inline-flex items-center gap-0.5 rounded-full bg-green-500/15 border border-green-500/30 px-1.5 py-0.5 text-[10px] font-semibold text-green-400">
                   <Sparkles className="h-2.5 w-2.5" />
                   New

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -87,3 +87,45 @@ export function getRevenueMultiple(askingPrice: number, mrr: number): string {
   const multiple = askingPrice / mrr;
   return `${multiple.toFixed(1)}×`;
 }
+
+// ── Tester Reputation Score ──────────────────────────────────────────────────
+
+export type TesterTier = "none" | "bronze" | "silver" | "gold";
+
+export function getTesterScore(stats: {
+  betaTestsCompleted: number;
+  feedbackGiven: number;
+}): { score: number; tier: TesterTier; label: string } {
+  if (stats.betaTestsCompleted === 0 && stats.feedbackGiven === 0)
+    return { score: 0, tier: "none", label: "" };
+  const raw = stats.betaTestsCompleted * 10 + stats.feedbackGiven * 5;
+  const score = Math.min(100, raw);
+  const tier: TesterTier = score >= 61 ? "gold" : score >= 26 ? "silver" : "bronze";
+  const label = `${tier.charAt(0).toUpperCase() + tier.slice(1)} Tester`;
+  return { score, tier, label };
+}
+
+// ── Listing Completeness Score ───────────────────────────────────────────────
+
+export function getListingCompleteness(listing: Listing): {
+  score: number;
+  missing: string[];
+} {
+  let score = 0;
+  const missing: string[] = [];
+
+  if (listing.title) score += 10;
+  if ((listing.pitch?.length ?? 0) > 50) score += 5; else missing.push("Longer pitch (50+ chars)");
+  if ((listing.description?.length ?? 0) > 200) score += 10; else missing.push("Detailed description");
+  if (listing.category) score += 5;
+  if (listing.techStack.length > 0) score += 10; else missing.push("Tech stack");
+  if (listing.assetsIncluded.length > 0) score += 5; else missing.push("Assets included");
+  if (listing.metrics.mrr > 0) score += 10; else missing.push("Monthly revenue (MRR)");
+  if (listing.metrics.monthlyProfit > 0) score += 5; else missing.push("Monthly profit");
+  if (listing.metrics.monthlyVisitors > 0) score += 5; else missing.push("Monthly visitors");
+  if (listing.metrics.registeredUsers > 0) score += 5; else missing.push("Registered users");
+  if (listing.ownershipVerified) score += 15; else missing.push("Ownership verification");
+  if (listing.screenshots.length > 0) score += 10; else missing.push("Screenshots");
+
+  return { score: Math.min(100, score), missing };
+}

--- a/src/lib/db/connects.ts
+++ b/src/lib/db/connects.ts
@@ -68,7 +68,7 @@ async function ensureBalanceRow(
   return {};
 }
 
-async function mutateBalanceAtomic(
+export async function mutateBalanceAtomic(
   clerkUserId: string,
   delta: number
 ): Promise<BalanceMutationResult> {

--- a/src/lib/db/listings.ts
+++ b/src/lib/db/listings.ts
@@ -1,5 +1,8 @@
 import { createServerClient, createServiceClient } from "@/lib/supabase";
 import { Listing } from "@/types/listing";
+import { mutateBalanceAtomic } from "@/lib/db/connects";
+
+const FEATURE_COSTS: Record<7 | 14 | 30, number> = { 7: 5, 14: 8, 30: 15 };
 
 // Map Supabase row → Listing type used throughout the app
 function rowToListing(row: Record<string, unknown>): Listing {
@@ -11,7 +14,7 @@ function rowToListing(row: Record<string, unknown>): Listing {
     description: (row.description as string) ?? "",
     category: row.category as Listing["category"],
     techStack: (row.tech_stack as string[]) ?? [],
-    screenshots: [],
+    screenshots: (row.screenshots as string[]) ?? [],
     askingPrice: Number(row.asking_price),
     openToOffers: Boolean(row.open_to_offers),
     metrics: {
@@ -30,17 +33,20 @@ function rowToListing(row: Record<string, unknown>): Listing {
       (row.ownership_verification_method as Listing["ownershipVerificationMethod"]) ?? null,
     ownershipVerifiedAt: (row.ownership_verified_at as string) ?? null,
     featured: Boolean(row.featured),
+    featuredUntil: (row.featured_until as string) ?? null,
     createdAt: row.created_at as string,
     updatedAt: (row.updated_at as string) ?? (row.created_at as string),
   };
 }
+
+const PUBLIC_STATUSES = ["active", "under_offer"] as const;
 
 export async function getListings(): Promise<Listing[]> {
   const client = await createServerClient();
   const { data, error } = await client
     .from("listings")
     .select("*")
-    .eq("status", "active")
+    .in("status", PUBLIC_STATUSES)
     .order("created_at", { ascending: false });
   if (error || !data) return [];
   return data.map(rowToListing);
@@ -51,7 +57,7 @@ export async function getFeaturedListings(): Promise<Listing[]> {
   const { data, error } = await client
     .from("listings")
     .select("*")
-    .eq("status", "active")
+    .in("status", PUBLIC_STATUSES)
     .eq("featured", true)
     .order("created_at", { ascending: false });
   if (error || !data) return [];
@@ -101,7 +107,7 @@ export async function getSimilarListings(listing: Listing, count = 3): Promise<L
   const { data, error } = await client
     .from("listings")
     .select("*")
-    .eq("status", "active")
+    .in("status", PUBLIC_STATUSES)
     .eq("category", listing.category)
     .neq("id", listing.id)
     .limit(count);
@@ -127,7 +133,7 @@ export async function updateListing(
     title: string; pitch: string; description: string; category: string;
     techStack: string[]; askingPrice: number; openToOffers: boolean;
     mrr: number; monthlyProfit: number; monthlyVisitors: number;
-    registeredUsers: number; assetsIncluded: string[];
+    registeredUsers: number; assetsIncluded: string[]; screenshots: string[];
   }
 ): Promise<boolean> {
   const client = createServiceClient();
@@ -137,7 +143,7 @@ export async function updateListing(
     asking_price: payload.askingPrice, open_to_offers: payload.openToOffers,
     mrr: payload.mrr, monthly_profit: payload.monthlyProfit,
     monthly_visitors: payload.monthlyVisitors, registered_users: payload.registeredUsers,
-    assets_included: payload.assetsIncluded,
+    assets_included: payload.assetsIncluded, screenshots: payload.screenshots,
   }).eq("id", listingId).eq("seller_id", clerkUserId);
   return !error;
 }
@@ -145,7 +151,7 @@ export async function updateListing(
 export async function updateListingStatus(
   clerkUserId: string,
   listingId: string,
-  status: "active" | "sold" | "draft" | "pending_verification"
+  status: "active" | "sold" | "draft" | "pending_verification" | "under_offer"
 ): Promise<boolean> {
   const client = createServiceClient();
   const { error } = await client.from("listings").update({ status })
@@ -178,6 +184,7 @@ export async function createListing(
     monthlyVisitors: number;
     registeredUsers: number;
     assetsIncluded: string[];
+    screenshots?: string[];
   }
 ): Promise<{ id: string } | null> {
   const client = createServiceClient();
@@ -196,6 +203,7 @@ export async function createListing(
       monthly_visitors: payload.monthlyVisitors,
       registered_users: payload.registeredUsers,
       assets_included: payload.assetsIncluded,
+      screenshots: payload.screenshots ?? [],
       seller_id: clerkUserId,
       status: "pending_verification",
     })
@@ -222,4 +230,86 @@ export async function getUnlockedListings(clerkUserId: string): Promise<Listing[
       return rowToListing(listing);
     })
     .filter((listing): listing is Listing => listing !== null);
+}
+
+export async function recordListingView(
+  listingId: string,
+  viewerId: string | null
+): Promise<void> {
+  const client = createServiceClient();
+  await client.from("listing_views").insert({ listing_id: listingId, viewer_id: viewerId });
+}
+
+export async function featureListing(
+  clerkUserId: string,
+  listingId: string,
+  durationDays: 7 | 14 | 30
+): Promise<{ success?: boolean; error?: string }> {
+  const listing = await getListingByIdForSeller(clerkUserId, listingId);
+  if (!listing) return { error: "Listing not found." };
+
+  const cost = FEATURE_COSTS[durationDays];
+  const debited = await mutateBalanceAtomic(clerkUserId, -cost);
+  if (debited.insufficient) return { error: `Not enough Connects. This requires ${cost} connects.` };
+  if (debited.error) return { error: debited.error };
+
+  const featuredUntil = new Date(Date.now() + durationDays * 24 * 60 * 60 * 1000).toISOString();
+  const client = createServiceClient();
+
+  const { error: updateError } = await client
+    .from("listings")
+    .update({ featured: true, featured_until: featuredUntil })
+    .eq("id", listingId)
+    .eq("seller_id", clerkUserId);
+
+  if (updateError) {
+    await mutateBalanceAtomic(clerkUserId, cost);
+    return { error: "Could not feature listing right now. Please try again." };
+  }
+
+  await client.from("connects_transactions").insert({
+    clerk_user_id: clerkUserId,
+    amount: -cost,
+    type: "feature_boost",
+    description: `Listing featured for ${durationDays}d`,
+    listing_id: listingId,
+  });
+
+  return { success: true };
+}
+
+export async function expireFeaturedListings(): Promise<number> {
+  const client = createServiceClient();
+  const { data, error } = await client
+    .from("listings")
+    .update({ featured: false, featured_until: null })
+    .lt("featured_until", new Date().toISOString())
+    .eq("featured", true)
+    .select("id");
+  if (error) return 0;
+  return (data ?? []).length;
+}
+
+export async function getListingAnalytics(
+  listingIds: string[]
+): Promise<Record<string, { views: number; unlocks: number }>> {
+  if (listingIds.length === 0) return {};
+  const client = createServiceClient();
+
+  const [viewsRes, unlocksRes] = await Promise.all([
+    client.from("listing_views").select("listing_id").in("listing_id", listingIds),
+    client
+      .from("connects_transactions")
+      .select("listing_id")
+      .eq("type", "unlock")
+      .in("listing_id", listingIds),
+  ]);
+
+  const result: Record<string, { views: number; unlocks: number }> = {};
+  for (const id of listingIds) result[id] = { views: 0, unlocks: 0 };
+  for (const row of (viewsRes.data ?? []) as { listing_id: string }[])
+    result[row.listing_id].views++;
+  for (const row of (unlocksRes.data ?? []) as { listing_id: string }[])
+    result[row.listing_id].unlocks++;
+  return result;
 }

--- a/src/lib/db/offers.ts
+++ b/src/lib/db/offers.ts
@@ -1,0 +1,136 @@
+import { createServiceClient } from "@/lib/supabase";
+
+export interface Offer {
+  id: string;
+  listingId: string;
+  buyerId: string;
+  amountCents: number;
+  message: string;
+  status: "pending" | "accepted" | "rejected";
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface OfferWithListing extends Offer {
+  listingTitle: string;
+  listingAskingPrice: number;
+}
+
+function rowToOffer(row: Record<string, unknown>): Offer {
+  return {
+    id: row.id as string,
+    listingId: row.listing_id as string,
+    buyerId: row.buyer_id as string,
+    amountCents: Number(row.amount_cents),
+    message: (row.message as string) ?? "",
+    status: (row.status as Offer["status"]) ?? "pending",
+    createdAt: row.created_at as string,
+    updatedAt: row.updated_at as string,
+  };
+}
+
+export async function createOffer(
+  buyerId: string,
+  listingId: string,
+  amountCents: number,
+  message: string
+): Promise<{ id: string } | null> {
+  const client = createServiceClient();
+  const { data, error } = await client
+    .from("offers")
+    .insert({ buyer_id: buyerId, listing_id: listingId, amount_cents: amountCents, message })
+    .select("id")
+    .single();
+  if (error || !data) return null;
+  return { id: data.id };
+}
+
+export async function getOffersForListing(
+  sellerId: string,
+  listingId: string
+): Promise<Offer[]> {
+  const client = createServiceClient();
+  // Verify seller owns this listing
+  const { data: listing } = await client
+    .from("listings")
+    .select("id")
+    .eq("id", listingId)
+    .eq("seller_id", sellerId)
+    .maybeSingle();
+  if (!listing) return [];
+
+  const { data, error } = await client
+    .from("offers")
+    .select("*")
+    .eq("listing_id", listingId)
+    .order("created_at", { ascending: false });
+  if (error || !data) return [];
+  return (data as Record<string, unknown>[]).map(rowToOffer);
+}
+
+export async function getOffersForSeller(sellerId: string): Promise<OfferWithListing[]> {
+  const client = createServiceClient();
+  const { data, error } = await client
+    .from("offers")
+    .select("*, listings!inner(id, title, asking_price, seller_id)")
+    .eq("listings.seller_id", sellerId)
+    .order("created_at", { ascending: false });
+  if (error || !data) return [];
+
+  return (data as Record<string, unknown>[]).map((row) => {
+    const listing = row.listings as Record<string, unknown>;
+    return {
+      ...rowToOffer(row),
+      listingTitle: listing?.title as string ?? "",
+      listingAskingPrice: Number(listing?.asking_price ?? 0),
+    };
+  });
+}
+
+export async function getOffersForBuyer(buyerId: string): Promise<OfferWithListing[]> {
+  const client = createServiceClient();
+  const { data, error } = await client
+    .from("offers")
+    .select("*, listings(id, title, asking_price)")
+    .eq("buyer_id", buyerId)
+    .order("created_at", { ascending: false });
+  if (error || !data) return [];
+
+  return (data as Record<string, unknown>[]).map((row) => {
+    const listing = row.listings as Record<string, unknown> | null;
+    return {
+      ...rowToOffer(row),
+      listingTitle: listing?.title as string ?? "Deleted listing",
+      listingAskingPrice: Number(listing?.asking_price ?? 0),
+    };
+  });
+}
+
+export async function updateOfferStatus(
+  sellerId: string,
+  offerId: string,
+  status: "accepted" | "rejected"
+): Promise<boolean> {
+  const client = createServiceClient();
+  // Validate the offer's listing belongs to this seller
+  const { data: offer } = await client
+    .from("offers")
+    .select("listing_id")
+    .eq("id", offerId)
+    .maybeSingle();
+  if (!offer) return false;
+
+  const { data: listing } = await client
+    .from("listings")
+    .select("id")
+    .eq("id", (offer as Record<string, unknown>).listing_id)
+    .eq("seller_id", sellerId)
+    .maybeSingle();
+  if (!listing) return false;
+
+  const { error } = await client
+    .from("offers")
+    .update({ status, updated_at: new Date().toISOString() })
+    .eq("id", offerId);
+  return !error;
+}

--- a/src/lib/db/saved-searches.ts
+++ b/src/lib/db/saved-searches.ts
@@ -1,0 +1,87 @@
+import { createServiceClient } from "@/lib/supabase";
+
+export interface SavedSearch {
+  id: string;
+  clerkUserId: string;
+  email: string;
+  category: string | null;
+  maxPriceCents: number | null;
+  lastNotifiedAt: string | null;
+  createdAt: string;
+}
+
+function rowToSavedSearch(row: Record<string, unknown>): SavedSearch {
+  return {
+    id: row.id as string,
+    clerkUserId: row.clerk_user_id as string,
+    email: row.email as string,
+    category: (row.category as string) ?? null,
+    maxPriceCents: row.max_price_cents != null ? Number(row.max_price_cents) : null,
+    lastNotifiedAt: (row.last_notified_at as string) ?? null,
+    createdAt: row.created_at as string,
+  };
+}
+
+export async function createSavedSearch(
+  clerkUserId: string,
+  email: string,
+  category: string | null,
+  maxPriceCents: number | null
+): Promise<{ id: string } | null> {
+  const client = createServiceClient();
+  const { data, error } = await client
+    .from("saved_searches")
+    .insert({
+      clerk_user_id: clerkUserId,
+      email,
+      category: category || null,
+      max_price_cents: maxPriceCents || null,
+    })
+    .select("id")
+    .single();
+  if (error || !data) return null;
+  return { id: (data as { id: string }).id };
+}
+
+export async function getSavedSearchesByUser(clerkUserId: string): Promise<SavedSearch[]> {
+  const client = createServiceClient();
+  const { data, error } = await client
+    .from("saved_searches")
+    .select("*")
+    .eq("clerk_user_id", clerkUserId)
+    .order("created_at", { ascending: false });
+  if (error || !data) return [];
+  return (data as Record<string, unknown>[]).map(rowToSavedSearch);
+}
+
+export async function deleteSavedSearch(
+  clerkUserId: string,
+  id: string
+): Promise<boolean> {
+  const client = createServiceClient();
+  const { error } = await client
+    .from("saved_searches")
+    .delete()
+    .eq("id", id)
+    .eq("clerk_user_id", clerkUserId);
+  return !error;
+}
+
+export async function getAllPendingSavedSearches(): Promise<SavedSearch[]> {
+  const client = createServiceClient();
+  const { data, error } = await client
+    .from("saved_searches")
+    .select("*")
+    .or("last_notified_at.is.null,last_notified_at.lt." + new Date(Date.now() - 23 * 60 * 60 * 1000).toISOString());
+  if (error || !data) return [];
+  return (data as Record<string, unknown>[]).map(rowToSavedSearch);
+}
+
+export async function markSavedSearchesNotified(ids: string[]): Promise<void> {
+  if (ids.length === 0) return;
+  const client = createServiceClient();
+  await client
+    .from("saved_searches")
+    .update({ last_notified_at: new Date().toISOString() })
+    .in("id", ids);
+}

--- a/src/types/listing.ts
+++ b/src/types/listing.ts
@@ -31,11 +31,12 @@ export interface Listing {
   metrics: ListingMetrics;
   assetsIncluded: string[];
   sellerId: string;
-  status: "active" | "sold" | "draft" | "pending_verification";
+  status: "active" | "sold" | "draft" | "pending_verification" | "under_offer";
   ownershipVerified: boolean;
   ownershipVerificationMethod: "repo" | "domain" | "manual" | null;
   ownershipVerifiedAt: string | null;
   featured: boolean;
+  featuredUntil: string | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/supabase/20260304_featured_until.sql
+++ b/supabase/20260304_featured_until.sql
@@ -1,0 +1,3 @@
+-- Migration: add featured_until column to listings for timed featured upgrades
+
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS featured_until timestamptz;

--- a/supabase/20260304_listing_views_and_under_offer.sql
+++ b/supabase/20260304_listing_views_and_under_offer.sql
@@ -1,0 +1,22 @@
+-- Migration: listing_views table + under_offer status support
+-- Run this in your Supabase SQL editor or via CLI
+
+-- 1. Listing views table for seller analytics
+CREATE TABLE IF NOT EXISTS listing_views (
+  id         uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  listing_id text        NOT NULL,
+  viewer_id  text,                           -- NULL = unauthenticated visitor
+  viewed_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS listing_views_listing_id_idx ON listing_views (listing_id);
+
+-- Enable RLS (service role key bypasses it for our analytics writes)
+ALTER TABLE listing_views ENABLE ROW LEVEL SECURITY;
+
+-- No public read policy — analytics are only surfaced via the service client
+
+-- 2. Under-offer status
+-- If your `listings.status` column is a PostgreSQL ENUM, uncomment the line below.
+-- If it is a plain text/varchar column, no change is needed.
+-- ALTER TYPE listing_status ADD VALUE IF NOT EXISTS 'under_offer';

--- a/supabase/20260304_offers.sql
+++ b/supabase/20260304_offers.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS offers (
+  id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  listing_id    uuid        NOT NULL REFERENCES listings(id) ON DELETE CASCADE,
+  buyer_id      text        NOT NULL,
+  amount_cents  integer     NOT NULL CHECK (amount_cents > 0),
+  message       text        NOT NULL DEFAULT '',
+  status        text        NOT NULL DEFAULT 'pending'
+                CHECK (status IN ('pending', 'accepted', 'rejected')),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS offers_listing_idx ON offers (listing_id);
+CREATE INDEX IF NOT EXISTS offers_buyer_idx ON offers (buyer_id);
+
+ALTER TABLE offers ENABLE ROW LEVEL SECURITY;
+-- No anon/auth policies for now; app uses service-role DB access.

--- a/supabase/20260304_saved_searches.sql
+++ b/supabase/20260304_saved_searches.sql
@@ -1,0 +1,16 @@
+-- Migration: saved_searches table for listing alert notifications
+
+CREATE TABLE IF NOT EXISTS saved_searches (
+  id               uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  clerk_user_id    text        NOT NULL,
+  email            text        NOT NULL,
+  category         text,                     -- NULL = any category
+  max_price_cents  integer,                  -- NULL = any price
+  last_notified_at timestamptz,
+  created_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS saved_searches_user_idx ON saved_searches (clerk_user_id);
+
+ALTER TABLE saved_searches ENABLE ROW LEVEL SECURITY;
+-- Service role key used for all reads/writes (bypasses RLS)

--- a/supabase/20260304_screenshots.sql
+++ b/supabase/20260304_screenshots.sql
@@ -1,0 +1,5 @@
+-- Add screenshots array to listings
+ALTER TABLE listings ADD COLUMN IF NOT EXISTS screenshots text[] NOT NULL DEFAULT '{}';
+
+-- NOTE: You also need to create a public Supabase Storage bucket named "listing-screenshots".
+-- In Supabase Dashboard → Storage → New bucket → name: listing-screenshots → Public: yes

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,14 @@
     {
       "path": "/api/cron/admin/payout-reconciliation",
       "schedule": "30 2 * * *"
+    },
+    {
+      "path": "/api/cron/saved-search-alerts",
+      "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/cron/expire-featured-listings",
+      "schedule": "0 3 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add listing feature-boost flow with connects debit and auto-expiry cron
- add offers system (submit/respond) and dashboard offer surfaces
- add saved search alerts (create/delete + daily cron) and category browse pages
- add screenshot upload/edit support and listing view analytics
- add contact page and navbar connects badge via server wrapper
- add SQL migrations for screenshots, offers, saved searches, listing views, and featured_until

## Validation
- npm run lint
- npm test
- npm run build