### PR TITLE
Add hybrid seller contact mode (direct or proposal-gated)

### DIFF
--- a/src/app/api/cron/stale-listings/route.ts
+++ b/src/app/api/cron/stale-listings/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from "next/server";
+import { archiveStaleListings, getListingsToWarn, StaleListing } from "@/lib/db/listings";
+import { clerkClient } from "@clerk/nextjs/server";
+import { absoluteUrl } from "@/lib/seo";
+
+export const runtime = "nodejs";
+
+function isAuthorized(request: Request): boolean {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) return process.env.NODE_ENV !== "production";
+  return request.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+async function getSellerEmail(sellerId: string): Promise<string | null> {
+  try {
+    const client = await clerkClient();
+    const user = await client.users.getUser(sellerId);
+    return (
+      user.emailAddresses.find((e) => e.id === user.primaryEmailAddressId)?.emailAddress ?? null
+    );
+  } catch {
+    return null;
+  }
+}
+
+async function sendEmail(to: string, subject: string, text: string): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  if (!apiKey) return;
+  const from = process.env.INTEREST_FROM_EMAIL?.trim() || "SideFlip <onboarding@resend.dev>";
+  await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ from, to: [to], subject, text }),
+  });
+}
+
+async function notifySellers(listings: StaleListing[], type: "warn" | "archived"): Promise<void> {
+  // Group by sellerId to send one email per seller
+  const bySeller = new Map<string, StaleListing[]>();
+  for (const l of listings) {
+    const group = bySeller.get(l.sellerId) ?? [];
+    group.push(l);
+    bySeller.set(l.sellerId, group);
+  }
+
+  for (const [sellerId, sellerListings] of bySeller) {
+    const email = await getSellerEmail(sellerId);
+    if (!email) continue;
+
+    const listingLines = sellerListings
+      .map((l) => `• ${l.title} — ${absoluteUrl(`/listing/${l.id}`)}`)
+      .join("\n");
+
+    if (type === "warn") {
+      await sendEmail(
+        email,
+        `[SideFlip] Your listing${sellerListings.length > 1 ? "s" : ""} will be archived in 30 days`,
+        `Hi,\n\nYour listing${sellerListings.length > 1 ? "s have" : " has"} not been updated in 60 days and will be automatically archived in 30 more days if no action is taken:\n\n${listingLines}\n\nIf your project is still for sale, log in and click "Keep active" in your dashboard to keep it visible to buyers.\n\n${absoluteUrl("/dashboard")}\n\n— The SideFlip Team`
+      ).catch(() => null);
+    } else {
+      await sendEmail(
+        email,
+        `[SideFlip] Your listing${sellerListings.length > 1 ? "s have" : " has"} been archived`,
+        `Hi,\n\nYour listing${sellerListings.length > 1 ? "s have" : " has"} been automatically archived after 90 days of inactivity:\n\n${listingLines}\n\nTo re-activate, log in to your dashboard and update your listing.\n\n${absoluteUrl("/dashboard")}\n\n— The SideFlip Team`
+      ).catch(() => null);
+    }
+  }
+}
+
+export async function GET(request: Request) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ ok: false, error: "unauthorized" }, { status: 401 });
+  }
+
+  const [toWarn, archived] = await Promise.all([
+    getListingsToWarn(),
+    archiveStaleListings(),
+  ]);
+
+  // Fire-and-forget notifications
+  Promise.all([
+    notifySellers(toWarn, "warn"),
+    notifySellers(archived, "archived"),
+  ]).catch(() => null);
+
+  return NextResponse.json({
+    ok: true,
+    warned: toWarn.length,
+    archived: archived.length,
+  });
+}

--- a/src/app/connects/actions.ts
+++ b/src/app/connects/actions.ts
@@ -14,7 +14,11 @@ import { getListingById } from "@/lib/db/listings";
 import { revalidatePath } from "next/cache";
 import { absoluteUrl } from "@/lib/seo";
 
-async function notifySellerOfUnlock(sellerId: string, listingTitle: string): Promise<void> {
+async function notifySellerOfUnlock(
+  sellerId: string,
+  listingTitle: string,
+  contactMode: "direct" | "proposal"
+): Promise<void> {
   const apiKey = process.env.RESEND_API_KEY?.trim();
   const fromEmail = process.env.INTEREST_FROM_EMAIL?.trim() || "SideFlip <onboarding@resend.dev>";
   if (!apiKey) return;
@@ -32,7 +36,10 @@ async function notifySellerOfUnlock(sellerId: string, listingTitle: string): Pro
         from: fromEmail,
         to: [email],
         subject: `[SideFlip] A buyer is interested in "${listingTitle}"`,
-        text: `Great news! A buyer just unlocked your listing "${listingTitle}" on SideFlip.\n\nThey can now see your contact details and will reach out if they want to move forward.\n\nView your listing analytics: ${absoluteUrl("/dashboard")}\n\n— The SideFlip Team`,
+        text:
+          contactMode === "proposal"
+            ? `A buyer just unlocked your listing "${listingTitle}" and can now send you a proposal request.\n\nReview incoming proposals in your dashboard. Contact details are revealed to buyers only after you accept.\n\n${absoluteUrl("/dashboard")}\n\n— The SideFlip Team`
+            : `Great news! A buyer just unlocked your listing "${listingTitle}" on SideFlip.\n\nThey can now see your contact details and may reach out to move forward.\n\nView your listing analytics: ${absoluteUrl("/dashboard")}\n\n— The SideFlip Team`,
       }),
     });
   } catch {
@@ -73,7 +80,7 @@ export async function unlockListingAction(listingId: string): Promise<{ error?: 
     revalidatePath(`/listing/${listingId}`);
     revalidatePath("/connects");
     // Fire-and-forget seller notification
-    notifySellerOfUnlock(listing.sellerId, listing.title).catch(() => null);
+    notifySellerOfUnlock(listing.sellerId, listing.title, listing.contactMode).catch(() => null);
   }
   return result;
 }

--- a/src/app/create/actions.ts
+++ b/src/app/create/actions.ts
@@ -39,6 +39,7 @@ export async function createListingAction(payload: {
   techStack: string[];
   askingPrice: number;
   openToOffers: boolean;
+  contactMode: "direct" | "proposal";
   mrr: number;
   monthlyProfit: number;
   monthlyVisitors: number;
@@ -94,6 +95,7 @@ export async function createListingAction(payload: {
 
   const askingPriceError = validateMoneyField(payload.askingPrice, "Asking price", MAX_LISTING_PRICE);
   if (askingPriceError) return { error: askingPriceError };
+  const contactMode = payload.contactMode === "proposal" ? "proposal" : "direct";
 
   const mrrError = validateMoneyField(payload.mrr, "MRR", MAX_MRR);
   if (mrrError) return { error: mrrError };
@@ -179,6 +181,7 @@ export async function createListingAction(payload: {
     techStack,
     askingPrice: Math.round(payload.askingPrice * 100), // dollars → cents
     openToOffers: payload.openToOffers,
+    contactMode,
     mrr: Math.round(payload.mrr * 100),
     monthlyProfit: Math.round(payload.monthlyProfit * 100),
     monthlyVisitors: Math.floor(payload.monthlyVisitors),

--- a/src/app/create/create-form.tsx
+++ b/src/app/create/create-form.tsx
@@ -34,6 +34,7 @@ export function CreateForm() {
   const [techStack, setTechStack] = useState<string[]>([]);
   const [includeBeta, setIncludeBeta] = useState(false);
   const [betaRewardType, setBetaRewardType] = useState<"cash" | "premium_access">("cash");
+  const [contactMode, setContactMode] = useState<"direct" | "proposal">("direct");
   const [assets, setAssets] = useState<string[]>(["source_code", "documentation"]);
   const [mrr, setMrr] = useState("");
   const [askingPrice, setAskingPrice] = useState("");
@@ -85,6 +86,7 @@ export function CreateForm() {
       techStack,
       askingPrice: Number(fd.get("askingPrice")) || 0,
       openToOffers: fd.has("openToOffers"),
+      contactMode,
       mrr: Number(fd.get("mrr")) || 0,
       monthlyProfit: Number(fd.get("monthlyProfit")) || 0,
       monthlyVisitors: Number(fd.get("monthlyVisitors")) || 0,
@@ -271,6 +273,39 @@ export function CreateForm() {
             <label htmlFor="open-to-offers" className="text-sm text-zinc-400">
               Open to offers below asking price
             </label>
+          </div>
+          <div className="mt-4">
+            <label className="block text-sm text-zinc-400 mb-2">Buyer Contact Mode</label>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={() => setContactMode("direct")}
+                className={`rounded-lg border px-3 py-3 text-left transition-colors ${
+                  contactMode === "direct"
+                    ? "border-indigo-500/50 bg-indigo-500/10"
+                    : "border-zinc-800 bg-zinc-900 hover:border-zinc-700"
+                }`}
+              >
+                <p className="text-sm font-medium text-zinc-100">Direct (default)</p>
+                <p className="mt-1 text-xs text-zinc-500">
+                  Buyer spends Connects and sees your contact instantly.
+                </p>
+              </button>
+              <button
+                type="button"
+                onClick={() => setContactMode("proposal")}
+                className={`rounded-lg border px-3 py-3 text-left transition-colors ${
+                  contactMode === "proposal"
+                    ? "border-indigo-500/50 bg-indigo-500/10"
+                    : "border-zinc-800 bg-zinc-900 hover:border-zinc-700"
+                }`}
+              >
+                <p className="text-sm font-medium text-zinc-100">Proposal-gated</p>
+                <p className="mt-1 text-xs text-zinc-500">
+                  Buyer spends Connects, sends a message/optional offer, and contact unlocks only after you accept.
+                </p>
+              </button>
+            </div>
           </div>
         </section>
 

--- a/src/app/dashboard/actions.ts
+++ b/src/app/dashboard/actions.ts
@@ -1,11 +1,43 @@
 "use server";
 
-import { auth } from "@clerk/nextjs/server";
-import { deleteListing, updateListingStatus, featureListing } from "@/lib/db/listings";
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { deleteListing, updateListingStatus, featureListing, refreshListing } from "@/lib/db/listings";
 import { deleteDraftBetaTest } from "@/lib/db/beta-tests";
 import { deleteSavedSearch } from "@/lib/db/saved-searches";
 import { updateOfferStatus } from "@/lib/db/offers";
 import { revalidatePath } from "next/cache";
+import { absoluteUrl } from "@/lib/seo";
+
+async function notifyBuyerOfOfferResponse(
+  buyerId: string,
+  listingTitle: string,
+  status: "accepted" | "rejected"
+): Promise<void> {
+  const apiKey = process.env.RESEND_API_KEY?.trim();
+  if (!apiKey) return;
+  try {
+    const clerk = await clerkClient();
+    const buyer = await clerk.users.getUser(buyerId);
+    const email = buyer.emailAddresses.find((e) => e.id === buyer.primaryEmailAddressId)?.emailAddress;
+    if (!email) return;
+    const from = process.env.INTEREST_FROM_EMAIL?.trim() || "SideFlip <onboarding@resend.dev>";
+    const isAccepted = status === "accepted";
+    await fetch("https://api.resend.com/emails", {
+      method: "POST",
+      headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
+      body: JSON.stringify({
+        from,
+        to: [email],
+        subject: `[SideFlip] Your offer on "${listingTitle}" was ${isAccepted ? "accepted" : "declined"}`,
+        text: isAccepted
+          ? `Great news! The seller has accepted your offer on "${listingTitle}".\n\nLog in to your dashboard to view the details and follow up with the seller.\n\n${absoluteUrl("/dashboard")}\n\n— The SideFlip Team`
+          : `The seller has declined your offer on "${listingTitle}".\n\nYou can browse more listings at ${absoluteUrl("/browse")}\n\n— The SideFlip Team`,
+      }),
+    });
+  } catch {
+    // non-critical
+  }
+}
 
 export async function deleteListingAction(
   listingId: string
@@ -81,15 +113,30 @@ export async function deleteSavedSearchAction(
   return { success: true };
 }
 
+export async function refreshListingAction(
+  listingId: string
+): Promise<{ error?: string; success?: boolean }> {
+  const { userId } = await auth();
+  if (!userId) return { error: "Not authenticated" };
+  const ok = await refreshListing(userId, listingId);
+  if (!ok) return { error: "Could not refresh listing." };
+  revalidatePath("/dashboard");
+  revalidatePath(`/listing/${listingId}`);
+  return { success: true };
+}
+
 export async function respondToOfferAction(
   offerId: string,
   status: "accepted" | "rejected"
 ): Promise<{ error?: string; success?: boolean }> {
   const { userId } = await auth();
   if (!userId) return { error: "Not authenticated" };
-  const ok = await updateOfferStatus(userId, offerId, status);
-  if (!ok) return { error: "Failed to update offer." };
+  const result = await updateOfferStatus(userId, offerId, status);
+  if (!result.ok) return { error: "Failed to update offer." };
   revalidatePath("/dashboard");
+  if (result.buyerId && result.listingTitle) {
+    notifyBuyerOfOfferResponse(result.buyerId, result.listingTitle, status).catch(() => null);
+  }
   return { success: true };
 }
 

--- a/src/app/dashboard/dashboard-client.tsx
+++ b/src/app/dashboard/dashboard-client.tsx
@@ -46,6 +46,7 @@ import {
   boostListingAction,
   deleteSavedSearchAction,
   respondToOfferAction,
+  refreshListingAction,
 } from "./actions";
 
 const MONTHLY_DATA = [
@@ -151,6 +152,11 @@ export function DashboardClient({
     if (!window.confirm("Mark this listing as active again?")) return;
     const result = await markActiveAction(listingId);
     if (!result.error) setMyListings((prev) => prev.map((l) => l.id === listingId ? { ...l, status: "active" as const } : l));
+  };
+
+  const handleKeepActive = async (listingId: string) => {
+    await refreshListingAction(listingId);
+    setMyListings((prev) => prev.map((l) => l.id === listingId ? { ...l, updatedAt: new Date().toISOString() } : l));
   };
 
   const handleBoost = useCallback(async (listingId: string, durationDays: 7 | 14 | 30) => {
@@ -374,6 +380,21 @@ export function DashboardClient({
                         Featured until {new Date(listing.featuredUntil).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
                       </span>
                     )}
+                    {listing.status === "active" && (() => {
+                      const days = Math.floor((Date.now() - new Date(listing.updatedAt).getTime()) / 86400000);
+                      if (days < 30) return null;
+                      return (
+                        <div className="mt-1 flex items-center gap-2">
+                          <span className="text-xs text-amber-400">⚠ Not updated in {days}d</span>
+                          <button
+                            onClick={() => handleKeepActive(listing.id)}
+                            className="text-[10px] font-medium text-indigo-400 hover:text-indigo-300 underline underline-offset-2"
+                          >
+                            Keep active
+                          </button>
+                        </div>
+                      );
+                    })()}
                   </div>
                   <div className="flex items-center gap-2 shrink-0">
                     <Link href={`/listing/${listing.id}`}>
@@ -458,7 +479,9 @@ export function DashboardClient({
                   <div key={offer.id} className="flex items-center gap-4 rounded-lg border border-zinc-800 bg-zinc-900 px-4 py-3">
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 flex-wrap">
-                        <span className="font-medium text-zinc-200">{formatPrice(offer.amountCents)}</span>
+                        <span className="font-medium text-zinc-200">
+                          {offer.amountCents != null ? formatPrice(offer.amountCents) : "Proposal (no price)"}
+                        </span>
                         <Badge className={
                           offer.status === "accepted"
                             ? "bg-green-500/10 text-green-400 border-green-500/20"
@@ -677,7 +700,9 @@ export function DashboardClient({
                   >
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2 flex-wrap">
-                        <span className="font-medium text-zinc-200">{formatPrice(offer.amountCents)}</span>
+                        <span className="font-medium text-zinc-200">
+                          {offer.amountCents != null ? formatPrice(offer.amountCents) : "Proposal (no price)"}
+                        </span>
                         <Badge className={
                           offer.status === "accepted"
                             ? "bg-green-500/10 text-green-400 border-green-500/20"

--- a/src/app/listing/[id]/edit/actions.ts
+++ b/src/app/listing/[id]/edit/actions.ts
@@ -38,6 +38,7 @@ export async function updateListingAction(
     techStack: string[];
     askingPrice: number;
     openToOffers: boolean;
+    contactMode: "direct" | "proposal";
     mrr: number;
     monthlyProfit: number;
     monthlyVisitors: number;
@@ -104,6 +105,7 @@ export async function updateListingAction(
   const screenshots = (payload.screenshots ?? [])
     .filter((u) => typeof u === "string" && u.startsWith("https://"))
     .slice(0, 10);
+  const contactMode = payload.contactMode === "proposal" ? "proposal" : "direct";
 
   const ok = await updateListing(userId, safeListingId, {
     title,
@@ -113,6 +115,7 @@ export async function updateListingAction(
     techStack,
     askingPrice: Math.round(payload.askingPrice),
     openToOffers: Boolean(payload.openToOffers),
+    contactMode,
     mrr: Math.round(payload.mrr),
     monthlyProfit: Math.round(payload.monthlyProfit),
     monthlyVisitors: Math.floor(payload.monthlyVisitors),

--- a/src/app/listing/[id]/edit/edit-form.tsx
+++ b/src/app/listing/[id]/edit/edit-form.tsx
@@ -34,6 +34,7 @@ export function EditListingForm({ listing }: { listing: Listing }) {
   const [screenshots, setScreenshots] = useState<string[]>(listing.screenshots);
   const [uploadingScreenshot, setUploadingScreenshot] = useState(false);
   const [screenshotError, setScreenshotError] = useState("");
+  const [contactMode, setContactMode] = useState<"direct" | "proposal">(listing.contactMode ?? "direct");
   // prices stored as dollars in state (DB is in cents)
   const [mrr, setMrr] = useState(String(listing.metrics.mrr / 100));
   const [askingPrice, setAskingPrice] = useState(String(listing.askingPrice / 100));
@@ -99,6 +100,7 @@ export function EditListingForm({ listing }: { listing: Listing }) {
       techStack,
       askingPrice: Math.round((Number(fd.get("askingPrice")) || 0) * 100),
       openToOffers: fd.has("openToOffers"),
+      contactMode,
       mrr: Math.round((Number(fd.get("mrr")) || 0) * 100),
       monthlyProfit: Math.round((Number(fd.get("monthlyProfit")) || 0) * 100),
       monthlyVisitors: Number(fd.get("monthlyVisitors")) || 0,
@@ -236,6 +238,39 @@ export function EditListingForm({ listing }: { listing: Listing }) {
               className="h-4 w-4 rounded border-zinc-700 bg-zinc-900 accent-indigo-600"
             />
             <label htmlFor="open-to-offers" className="text-sm text-zinc-400">Open to offers below asking price</label>
+          </div>
+          <div className="mt-4">
+            <label className="block text-sm text-zinc-400 mb-2">Buyer Contact Mode</label>
+            <div className="grid gap-2 sm:grid-cols-2">
+              <button
+                type="button"
+                onClick={() => setContactMode("direct")}
+                className={`rounded-lg border px-3 py-3 text-left transition-colors ${
+                  contactMode === "direct"
+                    ? "border-indigo-500/50 bg-indigo-500/10"
+                    : "border-zinc-800 bg-zinc-900 hover:border-zinc-700"
+                }`}
+              >
+                <p className="text-sm font-medium text-zinc-100">Direct</p>
+                <p className="mt-1 text-xs text-zinc-500">
+                  Buyer spends Connects and sees your contact instantly.
+                </p>
+              </button>
+              <button
+                type="button"
+                onClick={() => setContactMode("proposal")}
+                className={`rounded-lg border px-3 py-3 text-left transition-colors ${
+                  contactMode === "proposal"
+                    ? "border-indigo-500/50 bg-indigo-500/10"
+                    : "border-zinc-800 bg-zinc-900 hover:border-zinc-700"
+                }`}
+              >
+                <p className="text-sm font-medium text-zinc-100">Proposal-gated</p>
+                <p className="mt-1 text-xs text-zinc-500">
+                  Buyer unlocks, sends proposal, and contact is revealed only after you accept.
+                </p>
+              </button>
+            </div>
           </div>
         </section>
 

--- a/src/app/listing/[id]/offer-actions.ts
+++ b/src/app/listing/[id]/offer-actions.ts
@@ -4,13 +4,15 @@ import { auth } from "@clerk/nextjs/server";
 import { clerkClient } from "@clerk/nextjs/server";
 import { createOffer, updateOfferStatus } from "@/lib/db/offers";
 import { getListingById } from "@/lib/db/listings";
+import { isListingUnlocked } from "@/lib/db/connects";
 import { revalidatePath } from "next/cache";
 import { absoluteUrl } from "@/lib/seo";
 
 async function notifySellerOfOffer(
   sellerId: string,
   listingTitle: string,
-  amountCents: number
+  amountCents: number | null,
+  contactMode: "direct" | "proposal"
 ): Promise<void> {
   const apiKey = process.env.RESEND_API_KEY?.trim();
   if (!apiKey) return;
@@ -22,17 +24,26 @@ async function notifySellerOfOffer(
       (e) => e.id === seller.primaryEmailAddressId
     )?.emailAddress;
     if (!email) return;
-    const price = new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(
-      amountCents / 100
-    );
+    const price =
+      typeof amountCents === "number"
+        ? new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(
+            amountCents / 100
+          )
+        : null;
     await fetch("https://api.resend.com/emails", {
       method: "POST",
       headers: { Authorization: `Bearer ${apiKey}`, "Content-Type": "application/json" },
       body: JSON.stringify({
         from: fromEmail,
         to: [email],
-        subject: `[SideFlip] New offer of ${price} on "${listingTitle}"`,
-        text: `Good news! You received an offer of ${price} for "${listingTitle}" on SideFlip.\n\nLog in to your dashboard to review and respond.\n\n${absoluteUrl("/dashboard")}\n\n— The SideFlip Team`,
+        subject:
+          contactMode === "proposal"
+            ? `[SideFlip] New buyer proposal on "${listingTitle}"`
+            : `[SideFlip] New offer${price ? ` of ${price}` : ""} on "${listingTitle}"`,
+        text:
+          contactMode === "proposal"
+            ? `A buyer unlocked your listing "${listingTitle}" and sent a proposal request${price ? ` with an offer of ${price}` : ""}.\n\nAccept to reveal your contact details to this buyer.\n\n${absoluteUrl("/dashboard")}\n\n— The SideFlip Team`
+            : `Good news! You received an offer${price ? ` of ${price}` : ""} for "${listingTitle}" on SideFlip.\n\nLog in to your dashboard to review and respond.\n\n${absoluteUrl("/dashboard")}\n\n— The SideFlip Team`,
       }),
     });
   } catch {
@@ -42,7 +53,7 @@ async function notifySellerOfOffer(
 
 export async function submitOfferAction(
   listingId: string,
-  amountCents: number,
+  amountCents: number | null,
   message: string
 ): Promise<{ error?: string; success?: boolean }> {
   const { userId } = await auth();
@@ -50,19 +61,40 @@ export async function submitOfferAction(
 
   const listing = await getListingById(listingId);
   if (!listing) return { error: "Listing not found" };
-  if (!listing.openToOffers) return { error: "This listing is not accepting offers" };
-  if (userId === listing.sellerId) return { error: "You cannot make an offer on your own listing" };
-
-  if (!Number.isInteger(amountCents) || amountCents <= 0) {
-    return { error: "Enter a valid offer amount." };
+  if (listing.contactMode === "direct" && !listing.openToOffers) {
+    return { error: "This listing is not accepting offers" };
   }
-  if (amountCents > 10_000_000 * 100) return { error: "Offer amount is too large." };
+  if (userId === listing.sellerId) return { error: "You cannot make an offer on your own listing" };
+  if (listing.contactMode === "proposal") {
+    const unlocked = await isListingUnlocked(userId, listingId);
+    if (!unlocked) return { error: "Unlock this listing before sending a proposal." };
+  }
 
   const msg = (message ?? "").trim().slice(0, 500);
-  const result = await createOffer(userId, listingId, amountCents, msg);
+  const normalizedAmount =
+    typeof amountCents === "number" && Number.isFinite(amountCents)
+      ? Math.round(amountCents)
+      : null;
+
+  if (listing.contactMode === "proposal" && !msg) {
+    return { error: "Please include a short message for the seller." };
+  }
+
+  if (normalizedAmount !== null && (!Number.isInteger(normalizedAmount) || normalizedAmount <= 0)) {
+    return { error: "Enter a valid offer amount." };
+  }
+  if (normalizedAmount !== null && normalizedAmount > 10_000_000 * 100) {
+    return { error: "Offer amount is too large." };
+  }
+
+  if (listing.contactMode === "direct" && normalizedAmount === null) {
+    return { error: "Enter a valid offer amount." };
+  }
+
+  const result = await createOffer(userId, listingId, normalizedAmount, msg);
   if (!result) return { error: "Failed to submit offer. Please try again." };
 
-  notifySellerOfOffer(listing.sellerId, listing.title, amountCents).catch(() => null);
+  notifySellerOfOffer(listing.sellerId, listing.title, normalizedAmount, listing.contactMode).catch(() => null);
 
   revalidatePath(`/listing/${listingId}`);
   return { success: true };
@@ -75,8 +107,8 @@ export async function respondToOfferAction(
   const { userId } = await auth();
   if (!userId) return { error: "Not authenticated" };
 
-  const ok = await updateOfferStatus(userId, offerId, status);
-  if (!ok) return { error: "Failed to update offer. Please try again." };
+  const result = await updateOfferStatus(userId, offerId, status);
+  if (!result.ok) return { error: "Failed to update offer. Please try again." };
 
   revalidatePath("/dashboard");
   return { success: true };

--- a/src/app/listing/[id]/offer-section.tsx
+++ b/src/app/listing/[id]/offer-section.tsx
@@ -11,9 +11,21 @@ interface OfferSectionProps {
   listingId: string;
   askingPriceCents: number;
   userId: string | null;
+  contactMode: "direct" | "proposal";
+  openToOffers: boolean;
+  isUnlocked: boolean;
+  proposalAccepted: boolean;
 }
 
-export function OfferSection({ listingId, askingPriceCents, userId }: OfferSectionProps) {
+export function OfferSection({
+  listingId,
+  askingPriceCents,
+  userId,
+  contactMode,
+  openToOffers,
+  isUnlocked,
+  proposalAccepted,
+}: OfferSectionProps) {
   const [showForm, setShowForm] = useState(false);
   const [amount, setAmount] = useState("");
   const [message, setMessage] = useState("");
@@ -21,12 +33,34 @@ export function OfferSection({ listingId, askingPriceCents, userId }: OfferSecti
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
 
+  const isProposalMode = contactMode === "proposal";
+
+  if (isProposalMode && !isUnlocked) {
+    return (
+      <div className="mt-4 rounded-lg border border-zinc-700 bg-zinc-800/40 p-3 text-xs text-zinc-400">
+        Unlock this listing first, then send a proposal message to request seller contact access.
+      </div>
+    );
+  }
+
+  if (isProposalMode && proposalAccepted) {
+    return (
+      <div className="mt-4 rounded-lg border border-green-500/20 bg-green-500/5 p-3 text-xs text-green-300">
+        Your proposal was accepted. Seller contact details are now visible in the seller section.
+      </div>
+    );
+  }
+
+  if (!isProposalMode && !openToOffers) return null;
+
   if (success) {
     return (
       <div className="mt-4 flex items-start gap-2 rounded-lg border border-green-500/20 bg-green-500/5 p-4">
         <CheckCircle className="mt-0.5 h-4 w-4 shrink-0 text-green-400" />
         <p className="text-sm text-green-400">
-          Offer submitted! The seller has been notified. Check your dashboard for updates.
+          {isProposalMode
+            ? "Proposal sent! The seller has been notified and can accept to reveal contact details."
+            : "Offer submitted! The seller has been notified. Check your dashboard for updates."}
         </p>
       </div>
     );
@@ -48,7 +82,7 @@ export function OfferSection({ listingId, askingPriceCents, userId }: OfferSecti
           }}
         >
           <DollarSign className="mr-1.5 h-3.5 w-3.5" />
-          Make an offer
+          {isProposalMode ? "Send proposal" : "Make an offer"}
         </Button>
       </div>
     );
@@ -56,9 +90,18 @@ export function OfferSection({ listingId, askingPriceCents, userId }: OfferSecti
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const amountCents = Math.round((Number(amount) || 0) * 100);
-    if (!amountCents || amountCents <= 0) {
+    const hasAmount = amount.trim().length > 0;
+    const amountCents = hasAmount ? Math.round((Number(amount) || 0) * 100) : null;
+    if (!isProposalMode && (!amountCents || amountCents <= 0)) {
       setError("Enter a valid offer amount.");
+      return;
+    }
+    if (isProposalMode && hasAmount && (!amountCents || amountCents <= 0)) {
+      setError("Offer amount must be greater than zero.");
+      return;
+    }
+    if (isProposalMode && !message.trim()) {
+      setError("Please include a short message for the seller.");
       return;
     }
     setLoading(true);
@@ -80,25 +123,35 @@ export function OfferSection({ listingId, askingPriceCents, userId }: OfferSecti
       onSubmit={handleSubmit}
       className="mt-4 space-y-3 rounded-lg border border-zinc-700 bg-zinc-800/40 p-4"
     >
-      <p className="text-sm font-medium text-zinc-300">Make an offer</p>
+      <p className="text-sm font-medium text-zinc-300">
+        {isProposalMode ? "Send proposal to seller" : "Make an offer"}
+      </p>
       <div>
-        <label className="mb-1 block text-xs text-zinc-500">Your offer (USD)</label>
+        <label className="mb-1 block text-xs text-zinc-500">
+          {isProposalMode ? "Optional offer (USD)" : "Your offer (USD)"}
+        </label>
         <Input
           type="number"
-          min="1"
+          min={isProposalMode ? "0" : "1"}
           value={amount}
           onChange={(e) => setAmount(e.target.value)}
-          placeholder={String(suggestedPrice)}
+          placeholder={isProposalMode ? `e.g. ${suggestedPrice}` : String(suggestedPrice)}
           className="bg-zinc-900 border-zinc-700 text-sm"
-          required
+          required={!isProposalMode}
         />
       </div>
       <div>
-        <label className="mb-1 block text-xs text-zinc-500">Message (optional)</label>
+        <label className="mb-1 block text-xs text-zinc-500">
+          {isProposalMode ? "Message (required)" : "Message (optional)"}
+        </label>
         <Textarea
           value={message}
           onChange={(e) => setMessage(e.target.value)}
-          placeholder="Tell the seller about yourself and why you're interested..."
+          placeholder={
+            isProposalMode
+              ? "Introduce yourself and explain why you want to connect..."
+              : "Tell the seller about yourself and why you're interested..."
+          }
           className="bg-zinc-900 border-zinc-700 text-sm"
           rows={3}
           maxLength={500}

--- a/src/app/listing/[id]/page.tsx
+++ b/src/app/listing/[id]/page.tsx
@@ -16,13 +16,14 @@ import { PurchaseCard } from "@/components/listing/purchase-card";
 import { ListingCard } from "@/components/listing/listing-card";
 import { SellerWebsiteGate } from "./seller-section";
 import { OfferSection } from "./offer-section";
+import { hasAcceptedOfferForBuyer } from "@/lib/db/offers";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { JsonLd } from "@/components/shared/json-ld";
 import { TrendingUp, TrendingDown, Minus, CheckCircle, User, ShieldCheck, Lock } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { auth } from "@clerk/nextjs/server";
+import { auth, clerkClient } from "@clerk/nextjs/server";
 import type { Metadata } from "next";
 import { absoluteUrl, NO_INDEX_ROBOTS, publicPageMetadata } from "@/lib/seo";
 
@@ -103,6 +104,24 @@ export default async function ListingDetailPage({ params }: Props) {
 
   const sellerOtherListings = sellerListings.filter((l) => l.id !== listing.id).slice(0, 2);
   const unlockCost = getUnlockCost(listing.askingPrice);
+  const proposalAccepted =
+    userId && unlocked && listing.contactMode === "proposal"
+      ? await hasAcceptedOfferForBuyer(userId, listing.id)
+      : false;
+  const canRevealSellerContact =
+    isSeller ||
+    (unlocked && (listing.contactMode === "direct" || proposalAccepted));
+
+  let sellerEmail: string | null = null;
+  if (canRevealSellerContact && !isSeller) {
+    try {
+      const clerk = await clerkClient();
+      const sellerUser = await clerk.users.getUser(listing.sellerId);
+      sellerEmail = sellerUser.emailAddresses.find((e) => e.id === sellerUser.primaryEmailAddressId)?.emailAddress ?? null;
+    } catch {
+      // non-critical
+    }
+  }
 
   // Track view — fire after response is sent, skip seller's own views
   if (!isSeller && (listing.status === "active" || listing.status === "under_offer")) {
@@ -112,6 +131,9 @@ export default async function ListingDetailPage({ params }: Props) {
   const TrendIcon = listing.metrics.revenueTrend === "up" ? TrendingUp : listing.metrics.revenueTrend === "down" ? TrendingDown : Minus;
   const trendColor = listing.metrics.revenueTrend === "up" ? "text-green-400" : listing.metrics.revenueTrend === "down" ? "text-red-400" : "text-zinc-400";
   const revenueMultiple = getRevenueMultiple(listing.askingPrice, listing.metrics.mrr);
+  const daysSinceUpdate = Math.floor(
+    (Date.now() - new Date(listing.updatedAt).getTime()) / (1000 * 60 * 60 * 24)
+  );
 
   const assetLabels: Record<string, string> = {
     source_code: "Source Code", domain: "Domain Name", user_database: "User Database",
@@ -205,7 +227,11 @@ export default async function ListingDetailPage({ params }: Props) {
                       : "Pending verification"}
                   </span>
                 </p>
-                <p className="mt-1">Seller contact stays locked until buyer unlocks with connects.</p>
+                {listing.contactMode === "proposal" ? (
+                  <p className="mt-1">This listing uses proposal-gated contact: buyers unlock, send a proposal, and contact is revealed only after seller acceptance.</p>
+                ) : (
+                  <p className="mt-1">This listing uses direct contact: buyers unlock with connects and can reach out immediately.</p>
+                )}
                 <p className="mt-1">Deals close off-platform between buyer and seller; escrow is recommended for larger amounts.</p>
               </div>
             </div>
@@ -300,7 +326,7 @@ export default async function ListingDetailPage({ params }: Props) {
           {seller && (
             <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-4 mb-8">
               <h3 className="text-lg font-semibold text-zinc-50 mb-3">About the Seller</h3>
-              {!isSeller && !unlocked ? (
+              {!isSeller && !canRevealSellerContact ? (
                 <div className="rounded-lg border border-zinc-700 bg-zinc-800/50 p-4">
                   <div className="flex items-start gap-3">
                     <div className="flex h-10 w-10 items-center justify-center rounded-full bg-zinc-900/80 border border-zinc-700">
@@ -309,9 +335,15 @@ export default async function ListingDetailPage({ params }: Props) {
                     <div>
                       <p className="text-sm font-semibold text-zinc-200">Seller details are locked</p>
                       <p className="mt-1 text-xs text-zinc-500">
-                        Unlock this listing to view seller profile, website, and more projects from this seller.
+                        {listing.contactMode === "proposal" && unlocked
+                          ? "You unlocked this listing. Send a proposal and wait for seller acceptance to reveal contact details."
+                          : "Unlock this listing to view seller profile, website, and more projects from this seller."}
                       </p>
-                      <p className="mt-2 text-xs text-indigo-300">Use the unlock card on the right ({unlockCost} connects).</p>
+                      {!unlocked && (
+                        <p className="mt-2 text-xs text-indigo-300">
+                          Use the unlock card on the right ({unlockCost} connects).
+                        </p>
+                      )}
                     </div>
                   </div>
                 </div>
@@ -334,13 +366,24 @@ export default async function ListingDetailPage({ params }: Props) {
                         <span>Member since {new Date(seller.stats.memberSince).toLocaleDateString("en-US", { month: "short", year: "numeric" })}</span>
                         <SellerWebsiteGate
                           listingId={listing.id}
-                          isUnlocked={unlocked}
-                          website={unlocked ? (seller.website ?? null) : null}
+                          canRevealContact={canRevealSellerContact}
+                          hasUnlocked={unlocked}
+                          contactMode={listing.contactMode}
+                          proposalAccepted={proposalAccepted}
+                          website={canRevealSellerContact ? (seller.website ?? null) : null}
                           userId={userId ?? null}
                           connectsBalance={connectsBalance}
                           unlockCost={unlockCost}
                         />
                       </div>
+                      {sellerEmail && (
+                        <div className="mt-2 flex items-center gap-2 rounded-md border border-green-500/20 bg-green-500/5 px-3 py-2">
+                          <span className="text-xs text-zinc-400">Contact:</span>
+                          <a href={`mailto:${sellerEmail}`} className="text-xs font-medium text-green-400 hover:text-green-300 break-all">
+                            {sellerEmail}
+                          </a>
+                        </div>
+                      )}
                     </div>
                   </div>
                   {sellerOtherListings.length > 0 && (
@@ -374,6 +417,13 @@ export default async function ListingDetailPage({ params }: Props) {
             </div>
           ) : (
             <>
+              {!isSeller && daysSinceUpdate >= 30 && (
+                <div className="mb-4 rounded-lg border border-amber-500/20 bg-amber-500/5 p-3">
+                  <p className="text-xs text-amber-400">
+                    ⚠ Last updated {daysSinceUpdate}d ago. Confirm the seller is still active before spending Connects.
+                  </p>
+                </div>
+              )}
               <PurchaseCard
                 askingPrice={formatPrice(listing.askingPrice)}
                 openToOffers={listing.openToOffers}
@@ -383,15 +433,21 @@ export default async function ListingDetailPage({ params }: Props) {
                 mrr={formatPrice(listing.metrics.mrr)}
                 listingId={listing.id}
                 isUnlocked={unlocked}
+                contactMode={listing.contactMode}
+                proposalAccepted={proposalAccepted}
                 userId={userId ?? null}
                 connectsBalance={connectsBalance}
                 unlockCost={unlockCost}
               />
-              {listing.openToOffers && !isSeller && (
+              {!isSeller && (listing.contactMode === "proposal" || listing.openToOffers) && (
                 <OfferSection
                   listingId={listing.id}
                   askingPriceCents={listing.askingPrice}
                   userId={userId ?? null}
+                  contactMode={listing.contactMode}
+                  openToOffers={listing.openToOffers}
+                  isUnlocked={unlocked}
+                  proposalAccepted={proposalAccepted}
                 />
               )}
             </>

--- a/src/app/listing/[id]/seller-section.tsx
+++ b/src/app/listing/[id]/seller-section.tsx
@@ -9,14 +9,27 @@ import { toSafeWebsiteUrl } from "@/lib/validation/profile";
 
 interface Props {
   listingId: string;
-  isUnlocked: boolean;
+  canRevealContact: boolean;
+  hasUnlocked: boolean;
+  contactMode: "direct" | "proposal";
+  proposalAccepted: boolean;
   website: string | null;
   userId: string | null;
   connectsBalance: number;
   unlockCost: number;
 }
 
-export function SellerWebsiteGate({ listingId, isUnlocked, website, userId, connectsBalance, unlockCost }: Props) {
+export function SellerWebsiteGate({
+  listingId,
+  canRevealContact,
+  hasUnlocked,
+  contactMode,
+  proposalAccepted,
+  website,
+  userId,
+  connectsBalance,
+  unlockCost,
+}: Props) {
   const router = useRouter();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -42,7 +55,7 @@ export function SellerWebsiteGate({ listingId, isUnlocked, website, userId, conn
     );
   }
 
-  if (isUnlocked) {
+  if (canRevealContact) {
     const safeWebsite = toSafeWebsiteUrl(website);
     if (!safeWebsite) return <span className="text-zinc-600">No website listed</span>;
     return (
@@ -50,6 +63,10 @@ export function SellerWebsiteGate({ listingId, isUnlocked, website, userId, conn
         Website <ExternalLink className="h-3 w-3" />
       </a>
     );
+  }
+
+  if (hasUnlocked && contactMode === "proposal" && !proposalAccepted) {
+    return <span className="text-zinc-500">Pending seller acceptance</span>;
   }
 
   return (

--- a/src/components/listing/listing-card.tsx
+++ b/src/components/listing/listing-card.tsx
@@ -49,6 +49,8 @@ const CATEGORY_TEXT_COLORS: Record<string, string> = {
 const HOT_VISITOR_THRESHOLD = 4000;
 const NEW_LISTING_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
 const NEW_LISTING_CUTOFF = Date.now() - NEW_LISTING_WINDOW_MS;
+const STALE_THRESHOLD_DAYS = 30;
+const NOW_TS = Date.now();
 
 interface ListingCardProps {
   listing: Listing;
@@ -73,6 +75,10 @@ export function ListingCard({ listing }: ListingCardProps) {
 
   const isNew = new Date(listing.createdAt).getTime() > NEW_LISTING_CUTOFF;
   const isHot = listing.metrics.monthlyVisitors >= HOT_VISITOR_THRESHOLD;
+  const daysSinceUpdate = Math.floor(
+    (NOW_TS - new Date(listing.updatedAt).getTime()) / (1000 * 60 * 60 * 24)
+  );
+  const isStale = daysSinceUpdate >= STALE_THRESHOLD_DAYS;
 
   const gradient = CATEGORY_GRADIENTS[listing.category] ?? "from-zinc-800 to-zinc-900";
   const initials = CATEGORY_INITIALS[listing.category] ?? "?";
@@ -106,6 +112,11 @@ export function ListingCard({ listing }: ListingCardProps) {
               {listing.status === "under_offer" && (
                 <span className="inline-flex items-center gap-0.5 rounded-full bg-violet-500/15 border border-violet-500/30 px-1.5 py-0.5 text-[10px] font-semibold text-violet-300">
                   Under Offer
+                </span>
+              )}
+              {listing.contactMode === "proposal" && (
+                <span className="inline-flex items-center gap-0.5 rounded-full bg-indigo-500/15 border border-indigo-500/30 px-1.5 py-0.5 text-[10px] font-semibold text-indigo-300">
+                  Proposal Gate
                 </span>
               )}
               {isNew && listing.status !== "under_offer" && (
@@ -160,7 +171,12 @@ export function ListingCard({ listing }: ListingCardProps) {
                 {formatPrice(listing.askingPrice)}
               </span>
               <div className="flex items-center gap-2">
-                {listing.ownershipVerified && (
+                {isStale && (
+                  <span className="text-[10px] text-amber-500/80" title={`Last updated ${daysSinceUpdate} days ago`}>
+                    ⚠ {daysSinceUpdate}d ago
+                  </span>
+                )}
+                {!isStale && listing.ownershipVerified && (
                   <span className="text-[10px] text-emerald-300 bg-emerald-500/10 border border-emerald-500/20 rounded px-1.5 py-0.5">
                     {listing.ownershipVerificationMethod === "repo"
                       ? "Repo verified"

--- a/src/components/listing/purchase-card.tsx
+++ b/src/components/listing/purchase-card.tsx
@@ -17,6 +17,8 @@ interface PurchaseCardProps {
   mrr?: string;
   listingId: string;
   isUnlocked: boolean;
+  contactMode: "direct" | "proposal";
+  proposalAccepted: boolean;
   userId: string | null;
   connectsBalance: number;
   unlockCost: number;
@@ -31,6 +33,8 @@ export function PurchaseCard({
   mrr,
   listingId,
   isUnlocked,
+  contactMode,
+  proposalAccepted,
   userId,
   connectsBalance,
   unlockCost,
@@ -55,7 +59,11 @@ export function PurchaseCard({
       setUnlocking(false);
       return;
     }
-    toast.success("Listing unlocked! Seller contact info is now visible.");
+    if (contactMode === "proposal") {
+      toast.success("Unlocked. Send your proposal request to the seller.");
+    } else {
+      toast.success("Listing unlocked! Seller contact info is now visible.");
+    }
     router.refresh();
   };
 
@@ -66,16 +74,27 @@ export function PurchaseCard({
 
       {isUnlocked ? (
         <div className="mt-4 rounded-lg border border-green-500/20 bg-green-500/5 p-4">
-          <p className="mb-1 text-sm font-semibold text-green-400">Seller info unlocked</p>
+          <p className="mb-1 text-sm font-semibold text-green-400">
+            {contactMode === "proposal" && !proposalAccepted
+              ? "Unlocked — awaiting seller acceptance"
+              : "Seller info unlocked"}
+          </p>
           <p className="text-xs text-zinc-400">
-            Check the seller section below for contact details. Reach out directly to discuss the acquisition.
+            {contactMode === "proposal" && !proposalAccepted
+              ? "Send a proposal/message below. Seller contact is revealed after acceptance."
+              : "Check the seller section below for contact details. Reach out directly to discuss the acquisition."}
           </p>
         </div>
       ) : (
         <div className="mt-4 rounded-lg border border-zinc-700 bg-zinc-800/50 p-4 text-center">
           <Lock className="h-5 w-5 text-zinc-500 mx-auto mb-2" />
-          <p className="text-sm font-medium text-zinc-300 mb-1">Unlock to connect with seller</p>
-          <p className="text-xs text-zinc-500 mb-3">Costs {unlockCost} connects — one-time per listing</p>
+          <p className="text-sm font-medium text-zinc-300 mb-1">
+            {contactMode === "proposal" ? "Unlock to send proposal request" : "Unlock to connect with seller"}
+          </p>
+          <p className="text-xs text-zinc-500 mb-3">
+            Costs {unlockCost} connects — one-time per listing
+            {contactMode === "proposal" ? ", then seller must accept to reveal contact" : ""}
+          </p>
           {!userId ? (
             <Link href="/sign-in">
               <Button size="sm" className="w-full bg-indigo-600 hover:bg-indigo-500">

--- a/src/lib/db/listings.ts
+++ b/src/lib/db/listings.ts
@@ -17,6 +17,7 @@ function rowToListing(row: Record<string, unknown>): Listing {
     screenshots: (row.screenshots as string[]) ?? [],
     askingPrice: Number(row.asking_price),
     openToOffers: Boolean(row.open_to_offers),
+    contactMode: (row.contact_mode as Listing["contactMode"]) ?? "direct",
     metrics: {
       mrr: Number(row.mrr),
       monthlyProfit: Number(row.monthly_profit),
@@ -132,6 +133,7 @@ export async function updateListing(
   payload: {
     title: string; pitch: string; description: string; category: string;
     techStack: string[]; askingPrice: number; openToOffers: boolean;
+    contactMode: Listing["contactMode"];
     mrr: number; monthlyProfit: number; monthlyVisitors: number;
     registeredUsers: number; assetsIncluded: string[]; screenshots: string[];
   }
@@ -141,6 +143,7 @@ export async function updateListing(
     title: payload.title, pitch: payload.pitch, description: payload.description,
     category: payload.category, tech_stack: payload.techStack,
     asking_price: payload.askingPrice, open_to_offers: payload.openToOffers,
+    contact_mode: payload.contactMode,
     mrr: payload.mrr, monthly_profit: payload.monthlyProfit,
     monthly_visitors: payload.monthlyVisitors, registered_users: payload.registeredUsers,
     assets_included: payload.assetsIncluded, screenshots: payload.screenshots,
@@ -179,6 +182,7 @@ export async function createListing(
     techStack: string[];
     askingPrice: number;
     openToOffers: boolean;
+    contactMode: Listing["contactMode"];
     mrr: number;
     monthlyProfit: number;
     monthlyVisitors: number;
@@ -198,6 +202,7 @@ export async function createListing(
       tech_stack: payload.techStack,
       asking_price: payload.askingPrice,
       open_to_offers: payload.openToOffers,
+      contact_mode: payload.contactMode,
       mrr: payload.mrr,
       monthly_profit: payload.monthlyProfit,
       monthly_visitors: payload.monthlyVisitors,
@@ -312,4 +317,60 @@ export async function getListingAnalytics(
   for (const row of (unlocksRes.data ?? []) as { listing_id: string }[])
     result[row.listing_id].unlocks++;
   return result;
+}
+
+export async function refreshListing(
+  clerkUserId: string,
+  listingId: string
+): Promise<boolean> {
+  const client = createServiceClient();
+  const { error } = await client
+    .from("listings")
+    .update({ updated_at: new Date().toISOString() })
+    .eq("id", listingId)
+    .eq("seller_id", clerkUserId);
+  return !error;
+}
+
+export interface StaleListing {
+  id: string;
+  sellerId: string;
+  title: string;
+}
+
+// Returns listings that just crossed the 60-day inactivity mark (within last 24h)
+export async function getListingsToWarn(): Promise<StaleListing[]> {
+  const client = createServiceClient();
+  const sixty = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString();
+  const sixtyOne = new Date(Date.now() - 61 * 24 * 60 * 60 * 1000).toISOString();
+  const { data, error } = await client
+    .from("listings")
+    .select("id, seller_id, title")
+    .eq("status", "active")
+    .lt("updated_at", sixty)
+    .gte("updated_at", sixtyOne);
+  if (error || !data) return [];
+  return (data as Record<string, unknown>[]).map((row) => ({
+    id: row.id as string,
+    sellerId: row.seller_id as string,
+    title: row.title as string,
+  }));
+}
+
+// Auto-drafts listings inactive for 90+ days, returns them for notification
+export async function archiveStaleListings(): Promise<StaleListing[]> {
+  const client = createServiceClient();
+  const ninety = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000).toISOString();
+  const { data, error } = await client
+    .from("listings")
+    .update({ status: "draft" })
+    .eq("status", "active")
+    .lt("updated_at", ninety)
+    .select("id, seller_id, title");
+  if (error || !data) return [];
+  return (data as Record<string, unknown>[]).map((row) => ({
+    id: row.id as string,
+    sellerId: row.seller_id as string,
+    title: row.title as string,
+  }));
 }

--- a/src/lib/db/offers.ts
+++ b/src/lib/db/offers.ts
@@ -4,7 +4,7 @@ export interface Offer {
   id: string;
   listingId: string;
   buyerId: string;
-  amountCents: number;
+  amountCents: number | null;
   message: string;
   status: "pending" | "accepted" | "rejected";
   createdAt: string;
@@ -21,7 +21,7 @@ function rowToOffer(row: Record<string, unknown>): Offer {
     id: row.id as string,
     listingId: row.listing_id as string,
     buyerId: row.buyer_id as string,
-    amountCents: Number(row.amount_cents),
+    amountCents: row.amount_cents == null ? null : Number(row.amount_cents),
     message: (row.message as string) ?? "",
     status: (row.status as Offer["status"]) ?? "pending",
     createdAt: row.created_at as string,
@@ -32,7 +32,7 @@ function rowToOffer(row: Record<string, unknown>): Offer {
 export async function createOffer(
   buyerId: string,
   listingId: string,
-  amountCents: number,
+  amountCents: number | null,
   message: string
 ): Promise<{ id: string } | null> {
   const client = createServiceClient();
@@ -110,27 +110,47 @@ export async function updateOfferStatus(
   sellerId: string,
   offerId: string,
   status: "accepted" | "rejected"
-): Promise<boolean> {
+): Promise<{ ok: boolean; buyerId?: string; listingTitle?: string } > {
   const client = createServiceClient();
-  // Validate the offer's listing belongs to this seller
+  // Validate the offer's listing belongs to this seller, and get buyer_id
   const { data: offer } = await client
     .from("offers")
-    .select("listing_id")
+    .select("listing_id, buyer_id")
     .eq("id", offerId)
     .maybeSingle();
-  if (!offer) return false;
+  if (!offer) return { ok: false };
 
+  const offerRow = offer as Record<string, unknown>;
   const { data: listing } = await client
     .from("listings")
-    .select("id")
-    .eq("id", (offer as Record<string, unknown>).listing_id)
+    .select("id, title")
+    .eq("id", offerRow.listing_id)
     .eq("seller_id", sellerId)
     .maybeSingle();
-  if (!listing) return false;
+  if (!listing) return { ok: false };
 
+  const listingRow = listing as Record<string, unknown>;
   const { error } = await client
     .from("offers")
     .update({ status, updated_at: new Date().toISOString() })
     .eq("id", offerId);
-  return !error;
+  if (error) return { ok: false };
+  return { ok: true, buyerId: offerRow.buyer_id as string, listingTitle: listingRow.title as string };
+}
+
+export async function hasAcceptedOfferForBuyer(
+  buyerId: string,
+  listingId: string
+): Promise<boolean> {
+  const client = createServiceClient();
+  const { data, error } = await client
+    .from("offers")
+    .select("id")
+    .eq("buyer_id", buyerId)
+    .eq("listing_id", listingId)
+    .eq("status", "accepted")
+    .limit(1)
+    .maybeSingle();
+  if (error) return false;
+  return Boolean(data);
 }

--- a/src/types/listing.ts
+++ b/src/types/listing.ts
@@ -28,6 +28,7 @@ export interface Listing {
   screenshots: string[];
   askingPrice: number;
   openToOffers: boolean;
+  contactMode: "direct" | "proposal";
   metrics: ListingMetrics;
   assetsIncluded: string[];
   sellerId: string;

--- a/supabase/20260304_offers.sql
+++ b/supabase/20260304_offers.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS offers (
   id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
   listing_id    uuid        NOT NULL REFERENCES listings(id) ON DELETE CASCADE,
   buyer_id      text        NOT NULL,
-  amount_cents  integer     NOT NULL CHECK (amount_cents > 0),
+  amount_cents  integer     CHECK (amount_cents IS NULL OR amount_cents > 0),
   message       text        NOT NULL DEFAULT '',
   status        text        NOT NULL DEFAULT 'pending'
                 CHECK (status IN ('pending', 'accepted', 'rejected')),

--- a/supabase/20260305_contact_mode_and_proposals.sql
+++ b/supabase/20260305_contact_mode_and_proposals.sql
@@ -1,0 +1,32 @@
+-- Add listing contact mode:
+-- direct   = unlock reveals seller contact immediately
+-- proposal = unlock allows proposal; seller acceptance reveals contact
+ALTER TABLE listings
+  ADD COLUMN IF NOT EXISTS contact_mode text NOT NULL DEFAULT 'direct';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'listings_contact_mode_check'
+  ) THEN
+    ALTER TABLE listings
+      ADD CONSTRAINT listings_contact_mode_check
+      CHECK (contact_mode IN ('direct', 'proposal'));
+  END IF;
+END $$;
+
+-- Allow proposal-only messages without a numeric offer amount.
+ALTER TABLE offers
+  ALTER COLUMN amount_cents DROP NOT NULL;
+
+ALTER TABLE offers
+  DROP CONSTRAINT IF EXISTS offers_amount_cents_check;
+
+ALTER TABLE offers
+  ADD CONSTRAINT offers_amount_cents_check
+  CHECK (amount_cents IS NULL OR amount_cents > 0);
+
+CREATE INDEX IF NOT EXISTS offers_listing_buyer_status_idx
+  ON offers (listing_id, buyer_id, status);

--- a/vercel.json
+++ b/vercel.json
@@ -15,6 +15,10 @@
     {
       "path": "/api/cron/expire-featured-listings",
       "schedule": "0 3 * * *"
+    },
+    {
+      "path": "/api/cron/stale-listings",
+      "schedule": "0 9 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add listing-level `contactMode` with two options: `direct` and `proposal`
- direct mode keeps current behavior (unlock -> contact reveal)
- proposal mode requires unlock, proposal message/optional offer, and seller acceptance before reveal
- update create/edit forms, listing detail UX, purchase/offer components, and offer handling
- add SQL migration for `listings.contact_mode` and nullable proposal amounts in `offers`
- include stale listing cron route and schedule updates present in local changes

## Validation
- npm run lint
- npm test
- npm run build