### PR TITLE
Refine browse and beta cards with spotlight rails

### DIFF
--- a/src/app/beta/beta-client.tsx
+++ b/src/app/beta/beta-client.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from "react";
 import { BetaTest } from "@/types/beta-test";
 import { User } from "@/types/user";
 import { BetaGrid } from "@/components/beta/beta-grid";
+import { BetaSpotlightRail } from "@/components/beta/beta-spotlight-rail";
 import { SearchBar } from "@/components/shared/search-bar";
 import { PageHeader } from "@/components/shared/page-header";
 import { Badge } from "@/components/ui/badge";
@@ -43,12 +44,49 @@ export function BetaPageClient({ betaTests, draftBetaTests, canViewDrafts, topTe
     return result;
   }, [betaTests, draftBetaTests, search, statusFilter, fundedCashOnly]);
 
+  const spotlightBetaTests = useMemo(() => {
+    if (statusFilter === "draft") return [];
+
+    const fundedCash = filtered.filter(
+      (bt) => bt.reward.type === "cash" && bt.reward.poolStatus === "funded" && bt.status !== "closed"
+    );
+    if (fundedCash.length > 0) return fundedCash.slice(0, 3);
+
+    return [...filtered]
+      .filter((bt) => bt.status !== "draft")
+      .sort((a, b) => {
+        const readinessDelta =
+          Number(b.reward.poolStatus === "funded") - Number(a.reward.poolStatus === "funded");
+        if (readinessDelta !== 0) return readinessDelta;
+        return new Date(a.deadline).getTime() - new Date(b.deadline).getTime();
+      })
+      .slice(0, 3);
+  }, [filtered, statusFilter]);
+
+  const spotlightIds = new Set(spotlightBetaTests.map((betaTest) => betaTest.id));
+  const gridBetaTests =
+    filtered.length > spotlightBetaTests.length
+      ? filtered.filter((betaTest) => !spotlightIds.has(betaTest.id))
+      : filtered;
+
+  const fundedCount = betaTests.filter(
+    (betaTest) => betaTest.reward.type === "cash" && betaTest.reward.poolStatus === "funded"
+  ).length;
+  const openSpotCount = betaTests.reduce(
+    (sum, betaTest) => sum + Math.max(0, betaTest.spots.total - betaTest.spots.filled),
+    0
+  );
+
   const gridKey = `${statusFilter}:${fundedCashOnly}:${search.trim().toLowerCase()}:${filtered.length}`;
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
-      <div className="flex items-start justify-between mb-8">
-        <PageHeader title="Beta Test Board" description="Find projects to test and earn rewards" />
+      <div className="mb-8 flex items-start justify-between">
+        <PageHeader
+          eyebrow="Testing Board"
+          title="Beta Test Board"
+          description="Structured test runs with clearer rewards, funded cash pools, and approval-ready workflows."
+        />
         <div className="flex items-center gap-2 shrink-0">
           <Link href="/beta/create">
             <Button size="sm" className="bg-indigo-600 hover:bg-indigo-500 shrink-0">
@@ -69,6 +107,23 @@ export function BetaPageClient({ betaTests, draftBetaTests, canViewDrafts, topTe
               Drafts ({draftBetaTests.length})
             </Button>
           )}
+        </div>
+      </div>
+      <div className="mb-8 grid gap-3 sm:grid-cols-3">
+        <div className="rounded-[24px] border border-white/10 bg-[linear-gradient(180deg,rgba(9,18,32,0.95),rgba(5,11,20,0.95))] p-4">
+          <p className="eyebrow">Live tests</p>
+          <p className="mt-3 text-3xl font-semibold text-zinc-50">{betaTests.length}</p>
+          <p className="mt-1 text-sm text-slate-400">Active beta programs discoverable now</p>
+        </div>
+        <div className="rounded-[24px] border border-cyan-400/12 bg-[linear-gradient(180deg,rgba(6,16,28,0.96),rgba(5,10,18,0.96))] p-4">
+          <p className="eyebrow text-cyan-200/75">Funded cash</p>
+          <p className="mt-3 text-3xl font-semibold text-zinc-50">{fundedCount}</p>
+          <p className="mt-1 text-sm text-slate-400">Reward pools already ready for approvals</p>
+        </div>
+        <div className="rounded-[24px] border border-white/10 bg-[linear-gradient(180deg,rgba(9,18,32,0.95),rgba(5,11,20,0.95))] p-4">
+          <p className="eyebrow">Open tester slots</p>
+          <p className="mt-3 text-3xl font-semibold text-zinc-50">{openSpotCount}</p>
+          <p className="mt-1 text-sm text-slate-400">Seats still available across live tests</p>
         </div>
       </div>
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-[1fr_280px]">
@@ -144,13 +199,14 @@ export function BetaPageClient({ betaTests, draftBetaTests, canViewDrafts, topTe
                 exit={reduceMotion ? undefined : { opacity: 0, y: -8 }}
                 transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
               >
-                <BetaGrid betaTests={filtered} />
+                <BetaSpotlightRail betaTests={spotlightBetaTests} />
+                <BetaGrid betaTests={gridBetaTests} />
               </motion.div>
             </AnimatePresence>
           )}
         </div>
         <aside>
-          <div className="rounded-lg border border-zinc-800 bg-zinc-900 p-5 sticky top-24">
+          <div className="sticky top-24 rounded-[28px] border border-cyan-400/10 bg-[linear-gradient(180deg,rgba(10,19,34,0.96),rgba(6,12,22,0.96))] p-5">
             <div className="flex items-center gap-2 mb-4">
               <Trophy className="h-4 w-4 text-yellow-400" />
               <h3 className="text-sm font-semibold text-zinc-50">Top Beta Testers</h3>

--- a/src/app/browse/browse-client.tsx
+++ b/src/app/browse/browse-client.tsx
@@ -5,6 +5,7 @@ import { Listing } from "@/types/listing";
 import { ListingGrid } from "@/components/listing/listing-grid";
 import { ListingFilters } from "@/components/listing/listing-filters";
 import { PageHeader } from "@/components/shared/page-header";
+import { ListingSpotlightRail } from "@/components/listing/listing-spotlight-rail";
 import { CATEGORY_LABELS } from "@/lib/constants";
 import { X, SlidersHorizontal, Bell, BellRing } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -54,6 +55,25 @@ export function BrowseClient({ initialListings, userId, initialCategory }: Brows
     const rest = result.filter((l) => !l.featured);
     return [...featured, ...rest];
   }, [initialListings, search, category, verifiedOnly, sortBy, minPrice, maxPrice]);
+
+  const spotlightListings = useMemo(() => {
+    const featured = filtered.filter((listing) => listing.featured);
+    if (featured.length > 0) return featured.slice(0, 3);
+
+    return [...filtered]
+      .sort((a, b) => {
+        const trustDelta = Number(b.ownershipVerified) - Number(a.ownershipVerified);
+        if (trustDelta !== 0) return trustDelta;
+        return b.metrics.mrr - a.metrics.mrr;
+      })
+      .slice(0, 3);
+  }, [filtered]);
+
+  const spotlightIds = new Set(spotlightListings.map((listing) => listing.id));
+  const gridListings =
+    filtered.length > spotlightListings.length
+      ? filtered.filter((listing) => !spotlightIds.has(listing.id))
+      : filtered;
 
   const verifiedCount = filtered.filter((listing) => listing.ownershipVerified).length;
   const proposalCount = filtered.filter((listing) => listing.contactMode === "proposal").length;
@@ -105,8 +125,9 @@ export function BrowseClient({ initialListings, userId, initialCategory }: Brows
         <div className="flex flex-col gap-6 lg:flex-row lg:items-end lg:justify-between">
           <div className="max-w-3xl">
             <PageHeader
+              eyebrow="Deal Room"
               title="Browse Projects"
-              description="Tighter, trust-first listings with revenue, visitors, ownership proof, and seller contact rules up front."
+              description="Acquisition-ready side projects with cleaner deal sheets, trust markers, and clearer buyer flow before you spend connects."
             />
           </div>
           <div className="grid gap-3 sm:grid-cols-3 lg:w-[420px]">
@@ -121,9 +142,9 @@ export function BrowseClient({ initialListings, userId, initialCategory }: Brows
               <p className="mt-1 text-sm text-slate-400">Listings with ownership proof</p>
             </div>
             <div className="rounded-2xl border border-white/10 bg-white/[0.04] p-4">
-              <p className="eyebrow">Proposal gate</p>
+              <p className="eyebrow">Screened deals</p>
               <p className="mt-3 text-3xl font-semibold text-zinc-50">{proposalCount}</p>
-              <p className="mt-1 text-sm text-slate-400">Sellers screening buyers first</p>
+              <p className="mt-1 text-sm text-slate-400">Sellers screening buyers before reveal</p>
             </div>
           </div>
         </div>
@@ -195,6 +216,7 @@ export function BrowseClient({ initialListings, userId, initialCategory }: Brows
           <ListingFilters {...filtersProps} />
         </aside>
         <div>
+          <ListingSpotlightRail listings={spotlightListings} />
           {filtered.length === 0 ? (
             <div className="surface-panel flex flex-col items-center justify-center rounded-[32px] py-24 text-center">
               <p className="eyebrow">No matches</p>
@@ -203,7 +225,7 @@ export function BrowseClient({ initialListings, userId, initialCategory }: Brows
               <button onClick={clearAll} className="mt-4 text-sm text-sky-300 hover:text-sky-200">Clear all filters</button>
             </div>
           ) : (
-            <ListingGrid listings={filtered} />
+            <ListingGrid listings={gridListings} />
           )}
         </div>
       </div>

--- a/src/components/beta/beta-card.tsx
+++ b/src/components/beta/beta-card.tsx
@@ -4,10 +4,11 @@ import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { BetaTest } from "@/types/beta-test";
-import { CATEGORY_LABELS } from "@/lib/constants";
+import { CATEGORY_ACCENT_CLASSES, CATEGORY_LABELS } from "@/lib/constants";
 import { calculateCashBetaPayout } from "@/lib/payments/beta-payouts";
 import { TiltCardShell } from "@/components/shared/tilt-card-shell";
-import { ArrowUpRight, IndianRupee, ShieldCheck, Star, Users } from "lucide-react";
+import { ArrowUpRight, IndianRupee, Star, Users, WalletCards, Clock3, CheckCheck } from "lucide-react";
+import { ProductPreviewPanel } from "@/components/shared/product-preview-panel";
 
 interface BetaCardProps {
   betaTest: BetaTest;
@@ -70,105 +71,138 @@ export function BetaCard({ betaTest }: BetaCardProps) {
           className: "border-sky-500/30 bg-sky-500/10 text-sky-300",
           label: "Premium access reward",
         };
+  const accentClassName =
+    CATEGORY_ACCENT_CLASSES[betaTest.category] ?? "from-zinc-700/20 via-zinc-500/10 to-transparent";
+  const deadlineLabel = new Date(betaTest.deadline).toLocaleDateString("en-US", { month: "short", day: "numeric" });
 
   return (
     <TiltCardShell overlayClassName="rounded-[28px]">
       <Link href={`/beta/${betaTest.id}`} className="block h-full">
-        <Card className="card-hover flex h-full min-h-[396px] cursor-pointer flex-col gap-0 overflow-hidden rounded-[28px] border-white/10 bg-[#0b1120]/95 py-0">
-          <div className="h-1.5 w-full bg-gradient-to-r from-sky-400 via-blue-500 to-amber-300" />
-          <CardContent className="flex flex-1 flex-col p-0">
-            <div className="border-b border-white/[0.08] p-5">
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <p className="eyebrow">{CATEGORY_LABELS[betaTest.category]}</p>
-                  <h3 className="mt-4 line-clamp-2 min-h-[62px] text-2xl font-semibold leading-tight text-zinc-50">
-                    {betaTest.title}
-                  </h3>
-                </div>
-                <ArrowUpRight className="mt-1 h-4 w-4 shrink-0 text-slate-500" />
+        <Card className="card-hover flex h-full min-h-[520px] cursor-pointer flex-col gap-0 overflow-hidden rounded-[28px] border-white/10 bg-[#0b1120]/95 py-0">
+          <CardContent className="flex flex-1 flex-col p-5">
+            <ProductPreviewPanel
+              className="h-[188px]"
+              eyebrow={CATEGORY_LABELS[betaTest.category]}
+              accentClassName={accentClassName}
+              stats={[
+                { label: "Reward", value: betaTest.reward.type === "cash" ? formatCurrencyMinor(betaTest.reward.amount, betaTest.reward.currency) : "Access" },
+                { label: "Deadline", value: deadlineLabel },
+                { label: "Spots", value: `${betaTest.spots.total}` },
+                { label: "Left", value: `${spotsRemaining}` },
+              ]}
+              footer={betaTest.reward.type === "cash" ? "Reward pool review flow" : "Premium access onboarding"}
+            />
+
+            <div className="mt-5 flex items-start justify-between gap-3">
+              <div>
+                <p className="text-xs uppercase tracking-[0.26em] text-slate-500">
+                  {CATEGORY_LABELS[betaTest.category]}  /  {statusLabel}
+                </p>
+                <h3 className="mt-3 line-clamp-2 min-h-[62px] text-[1.8rem] font-semibold leading-tight text-zinc-50">
+                  {betaTest.title}
+                </h3>
               </div>
-              <p className="mt-3 line-clamp-3 min-h-[72px] text-sm leading-6 text-slate-300">
-                {betaTest.description}
-              </p>
-              <div className="mt-4 flex flex-wrap gap-2">
-                <Badge className={statusColor}>{statusLabel}</Badge>
-                <Badge variant="outline" className={`border text-xs ${trustBadge.className}`}>
-                  {trustBadge.label}
-                </Badge>
-                {betaTest.platform.slice(0, 2).map((p) => (
-                  <Badge key={p} variant="outline" className="border-white/10 bg-white/5 text-slate-300 text-xs capitalize">
-                    {p}
-                  </Badge>
-                ))}
-              </div>
+              <ArrowUpRight className="mt-1 h-4 w-4 shrink-0 text-slate-500" />
             </div>
 
-            <div className="grid grid-cols-2 gap-px border-b border-white/[0.08] bg-white/[0.08]">
-              <div className="bg-[#0b1120] p-4">
+            <p className="mt-3 line-clamp-3 min-h-[72px] text-sm leading-6 text-slate-300">
+              {betaTest.description}
+            </p>
+
+            <div className="mt-4 flex min-h-6 flex-wrap gap-2">
+              <Badge className={statusColor}>{statusLabel}</Badge>
+              <Badge variant="outline" className={`border text-xs ${trustBadge.className}`}>
+                {trustBadge.label}
+              </Badge>
+              {betaTest.platform.slice(0, 1).map((p) => (
+                <Badge key={p} variant="outline" className="border-white/10 bg-white/5 text-slate-300 text-xs capitalize">
+                  {p}
+                </Badge>
+              ))}
+            </div>
+
+            <div className="mt-5 grid grid-cols-2 gap-3">
+              <div className="rounded-[20px] border border-white/10 bg-white/[0.04] p-4">
                 <p className="eyebrow">Reward</p>
                 <p className="mt-2 text-lg font-semibold text-amber-200">{betaTest.reward.description}</p>
               </div>
-              <div className="bg-[#0b1120] p-4">
+              <div className="rounded-[20px] border border-white/10 bg-white/[0.04] p-4">
                 <p className="eyebrow">Deadline</p>
+                <p className="mt-2 text-lg font-semibold text-zinc-50">{deadlineLabel}</p>
+              </div>
+              <div className="rounded-[20px] border border-white/10 bg-white/[0.04] p-4">
+                <p className="eyebrow">Capacity</p>
+                <p className="mt-2 text-lg font-semibold text-zinc-50">
+                  {betaTest.spots.filled}/{betaTest.spots.total}
+                </p>
+              </div>
+              <div className="rounded-[20px] border border-white/10 bg-white/[0.04] p-4">
+                <p className="eyebrow">Approval flow</p>
                 <p className="mt-2 text-sm font-medium text-zinc-50">
-                  {new Date(betaTest.deadline).toLocaleDateString("en-US", { month: "short", day: "numeric" })}
+                  {betaTest.reward.type === "cash" ? "SideFlip payout after approval" : "Creator grants access"}
                 </p>
               </div>
             </div>
 
-            <div className="flex flex-1 flex-col p-5">
-              <div className="rounded-[22px] border border-white/10 bg-white/[0.04] p-4">
-                <div className="flex items-center justify-between gap-3">
-                  <p className="eyebrow">Tester capacity</p>
-                  <span className="inline-flex items-center gap-1 text-xs text-slate-400">
-                    <Users className="h-3.5 w-3.5" />
-                    {spotsRemaining} left
-                  </span>
-                </div>
-                <div className="mt-3 h-2 rounded-full bg-white/[0.08]">
-                  <div
-                    className="h-2 rounded-full bg-gradient-to-r from-sky-400 to-blue-500 transition-all"
-                    style={{ width: `${fillPercent}%` }}
-                  />
-                </div>
-                <p className="mt-2 text-sm text-slate-400">
-                  {betaTest.spots.filled} of {betaTest.spots.total} spots filled
-                </p>
+            <div className="mt-4 rounded-[22px] border border-white/10 bg-white/[0.03] p-4">
+              <div className="flex items-center justify-between gap-3">
+                <p className="eyebrow">Tester capacity</p>
+                <span className="inline-flex items-center gap-1 text-xs text-slate-400">
+                  <Users className="h-3.5 w-3.5" />
+                  {spotsRemaining} left
+                </span>
               </div>
-
-              <div className="mt-4 flex min-h-6 flex-wrap gap-2">
-                {betaTest.reward.type === "cash" ? (
-                  <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/20 bg-emerald-400/10 px-2.5 py-1 text-[11px] font-medium text-emerald-200">
-                    <IndianRupee className="h-3 w-3" />
-                    SideFlip pays approved testers
-                  </span>
-                ) : (
-                  <span className="inline-flex items-center gap-1 rounded-full border border-sky-400/20 bg-sky-400/10 px-2.5 py-1 text-[11px] font-medium text-sky-200">
-                    <Star className="h-3 w-3" />
-                    Creator grants premium access directly
-                  </span>
-                )}
-                {betaTest.reward.poolStatus === "funded" && (
-                  <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/20 bg-emerald-400/10 px-2.5 py-1 text-[11px] font-medium text-emerald-200">
-                    <ShieldCheck className="h-3 w-3" />
-                    Ready for approvals
-                  </span>
-                )}
+              <div className="mt-3 h-2 rounded-full bg-white/[0.08]">
+                <div
+                  className="h-2 rounded-full bg-gradient-to-r from-cyan-400 to-blue-500 transition-all"
+                  style={{ width: `${fillPercent}%` }}
+                />
               </div>
-
-              <div className="mt-auto pt-5">
-                {cashPayout && (
-                  <p className="text-sm text-slate-300">
-                    Net tester payout after 5% fee:{" "}
-                    <span className="font-semibold text-zinc-50">
-                      {formatCurrencyMinor(cashPayout.netMinor, betaTest.reward.currency)}
-                    </span>
+              <div className="mt-4 grid grid-cols-1 gap-4 text-sm text-slate-300 sm:grid-cols-3">
+                <div>
+                  <p className="eyebrow">Funding</p>
+                  <p className="mt-2 inline-flex items-center gap-1 text-zinc-100">
+                    <WalletCards className="h-3.5 w-3.5 text-emerald-300" />
+                    {trustBadge.label}
                   </p>
-                )}
-                {!cashPayout && (
-                  <p className="text-sm text-slate-300">Best for onboarding power users before a wider launch.</p>
-                )}
+                </div>
+                <div>
+                  <p className="eyebrow">Flow</p>
+                  <p className="mt-2 inline-flex items-center gap-1 text-zinc-100">
+                    {betaTest.reward.type === "cash" ? (
+                      <IndianRupee className="h-3.5 w-3.5 text-emerald-300" />
+                    ) : (
+                      <Star className="h-3.5 w-3.5 text-sky-300" />
+                    )}
+                    {betaTest.reward.type === "cash" ? "Manual payouts after approval" : "Premium access reward"}
+                  </p>
+                </div>
+                <div>
+                  <p className="eyebrow">Readiness</p>
+                  <p className="mt-2 inline-flex items-center gap-1 text-zinc-100">
+                    {betaTest.reward.poolStatus === "funded" ? (
+                      <CheckCheck className="h-3.5 w-3.5 text-emerald-300" />
+                    ) : (
+                      <Clock3 className="h-3.5 w-3.5 text-amber-300" />
+                    )}
+                    {betaTest.reward.poolStatus === "funded" ? "Ready for approvals" : "Funding or onboarding pending"}
+                  </p>
+                </div>
               </div>
+            </div>
+
+            <div className="mt-auto pt-5">
+              {cashPayout && (
+                <p className="text-sm text-slate-300">
+                  Net tester payout after 5% fee:{" "}
+                  <span className="font-semibold text-zinc-50">
+                    {formatCurrencyMinor(cashPayout.netMinor, betaTest.reward.currency)}
+                  </span>
+                </p>
+              )}
+              {!cashPayout && (
+                <p className="text-sm text-slate-300">Best for onboarding power users before a wider launch.</p>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/src/components/beta/beta-grid.tsx
+++ b/src/components/beta/beta-grid.tsx
@@ -4,7 +4,6 @@ import { BetaTest } from "@/types/beta-test";
 import { BetaCard } from "./beta-card";
 import { motion, useReducedMotion } from "framer-motion";
 import { useMotionProfile } from "@/components/shared/use-motion-profile";
-import { cn } from "@/lib/utils";
 
 interface BetaGridProps {
   betaTests: BetaTest[];
@@ -44,10 +43,7 @@ export function BetaGrid({ betaTests }: BetaGridProps) {
       {betaTests.map((bt) => (
         <motion.div
           key={bt.id}
-          className={cn(
-            "h-full",
-            betaTests.length > 2 && bt === betaTests[0] ? "lg:col-span-2" : ""
-          )}
+          className="h-full"
           variants={
             disableHeavyMotion
               ? undefined

--- a/src/components/beta/beta-spotlight-rail.tsx
+++ b/src/components/beta/beta-spotlight-rail.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowUpRight, IndianRupee, ShieldCheck, Users } from "lucide-react";
+import { BetaTest } from "@/types/beta-test";
+import { CATEGORY_ACCENT_CLASSES, CATEGORY_LABELS } from "@/lib/constants";
+import { ProductPreviewPanel } from "@/components/shared/product-preview-panel";
+import { calculateCashBetaPayout } from "@/lib/payments/beta-payouts";
+
+interface BetaSpotlightRailProps {
+  betaTests: BetaTest[];
+}
+
+function formatReward(betaTest: BetaTest) {
+  if (betaTest.reward.type !== "cash") {
+    return betaTest.reward.description;
+  }
+
+  const normalized = betaTest.reward.currency.toUpperCase();
+  const amount = betaTest.reward.amount / 100;
+  try {
+    return new Intl.NumberFormat("en-IN", {
+      style: "currency",
+      currency: normalized,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  } catch {
+    return `${normalized} ${amount.toFixed(0)}`;
+  }
+}
+
+function formatMinor(amountMinor: number, currency: BetaTest["reward"]["currency"]) {
+  const normalized = currency.toUpperCase();
+  const amount = amountMinor / 100;
+  try {
+    return new Intl.NumberFormat("en-IN", {
+      style: "currency",
+      currency: normalized,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  } catch {
+    return `${normalized} ${amount.toFixed(0)}`;
+  }
+}
+
+export function BetaSpotlightRail({ betaTests }: BetaSpotlightRailProps) {
+  if (betaTests.length === 0) return null;
+
+  return (
+    <section className="mb-8 rounded-[32px] border border-cyan-400/10 bg-[linear-gradient(180deg,rgba(12,22,38,0.98),rgba(6,12,22,0.98))] p-5 shadow-[0_24px_80px_rgba(3,7,18,0.35)] sm:p-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="eyebrow text-cyan-200/80">Testing desk</p>
+          <h2 className="mt-2 text-2xl font-semibold text-zinc-50">Funded test runs ready now</h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
+            These tests are structured, funded, and already set up for approval flow instead of casual feedback collection.
+          </p>
+        </div>
+        <div className="rounded-full border border-cyan-400/15 bg-cyan-400/5 px-3 py-1.5 text-sm text-cyan-100/85">
+          {betaTests.length} ready this week
+        </div>
+      </div>
+
+      <div className="mt-5 flex snap-x gap-4 overflow-x-auto pb-1">
+        {betaTests.map((betaTest) => {
+          const cashPayout =
+            betaTest.reward.type === "cash" ? calculateCashBetaPayout(Number(betaTest.reward.amount ?? 0)) : null;
+
+          return (
+            <Link
+              key={betaTest.id}
+              href={`/beta/${betaTest.id}`}
+              className="group min-w-[290px] max-w-[320px] flex-1 snap-start rounded-[28px] border border-white/10 bg-[#08111f]/92 p-3 transition-colors hover:border-cyan-400/30"
+            >
+              <ProductPreviewPanel
+                className="h-[168px]"
+                eyebrow={CATEGORY_LABELS[betaTest.category]}
+                accentClassName={CATEGORY_ACCENT_CLASSES[betaTest.category] ?? "from-slate-500/25 to-slate-400/5"}
+                stats={[
+                  { label: "Reward", value: formatReward(betaTest) },
+                  { label: "Spots", value: `${betaTest.spots.total}` },
+                  { label: "Filled", value: `${betaTest.spots.filled}` },
+                  {
+                    label: "Pool",
+                    value:
+                      betaTest.reward.poolStatus === "funded"
+                        ? "Funded"
+                        : betaTest.reward.type === "cash"
+                          ? "Pending"
+                          : "Access",
+                  },
+                ]}
+                footer={betaTest.reward.type === "cash" ? "Manual payout flow live" : "Premium access reward"}
+              />
+
+              <div className="mt-4 flex items-start justify-between gap-3">
+                <div>
+                  <h3 className="line-clamp-2 text-lg font-semibold text-zinc-50">{betaTest.title}</h3>
+                  <p className="mt-2 line-clamp-2 text-sm leading-6 text-slate-400">{betaTest.description}</p>
+                </div>
+                <ArrowUpRight className="mt-1 h-4 w-4 shrink-0 text-slate-500 transition-colors group-hover:text-cyan-200" />
+              </div>
+
+              <div className="mt-4 flex items-center justify-between gap-3 text-sm">
+                <span className="inline-flex items-center gap-1 text-slate-300">
+                  {betaTest.reward.type === "cash" ? <IndianRupee className="h-3.5 w-3.5 text-emerald-300" /> : null}
+                  {cashPayout ? `Net ${formatMinor(cashPayout.netMinor, betaTest.reward.currency)}` : "Access reward"}
+                </span>
+                <span className="inline-flex items-center gap-1 text-slate-300">
+                  {betaTest.reward.poolStatus === "funded" ? (
+                    <ShieldCheck className="h-3.5 w-3.5 text-emerald-300" />
+                  ) : (
+                    <Users className="h-3.5 w-3.5 text-cyan-300" />
+                  )}
+                  {betaTest.spots.total - betaTest.spots.filled} spots left
+                </span>
+              </div>
+            </Link>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/listing/listing-card.tsx
+++ b/src/components/listing/listing-card.tsx
@@ -4,9 +4,6 @@ import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import {
-  TrendingUp,
-  TrendingDown,
-  Minus,
   Bookmark,
   BookmarkCheck,
   Flame,
@@ -14,25 +11,16 @@ import {
   ShieldCheck,
   Handshake,
   ArrowUpRight,
+  Clock3,
+  MessageSquareText,
 } from "lucide-react";
 import { Listing } from "@/types/listing";
 import { TechStackBadges } from "@/components/shared/tech-stack-badges";
 import { formatPrice, formatNumber } from "@/lib/formatting";
-import { CATEGORY_LABELS } from "@/lib/constants";
+import { CATEGORY_ACCENT_CLASSES, CATEGORY_LABELS } from "@/lib/constants";
 import { useWatchlist } from "@/lib/use-watchlist";
 import { TiltCardShell } from "@/components/shared/tilt-card-shell";
-
-// Category gradient backgrounds
-const CATEGORY_GRADIENTS: Record<string, string> = {
-  saas: "from-blue-500 to-sky-300",
-  "mobile-app": "from-sky-500 to-cyan-300",
-  "chrome-extension": "from-indigo-500 to-blue-300",
-  domain: "from-emerald-500 to-lime-300",
-  "open-source": "from-orange-500 to-amber-300",
-  "bot-automation": "from-cyan-500 to-teal-300",
-  api: "from-rose-500 to-orange-300",
-  "template-theme": "from-amber-500 to-yellow-300",
-};
+import { ProductPreviewPanel } from "@/components/shared/product-preview-panel";
 
 const HOT_VISITOR_THRESHOLD = 4000;
 const NEW_LISTING_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
@@ -47,20 +35,6 @@ interface ListingCardProps {
 export function ListingCard({ listing }: ListingCardProps) {
   const { isWatchlisted, toggle } = useWatchlist(listing.id);
 
-  const TrendIcon =
-    listing.metrics.revenueTrend === "up"
-      ? TrendingUp
-      : listing.metrics.revenueTrend === "down"
-      ? TrendingDown
-      : Minus;
-
-  const trendColor =
-    listing.metrics.revenueTrend === "up"
-      ? "text-green-500"
-      : listing.metrics.revenueTrend === "down"
-      ? "text-red-500"
-      : "text-zinc-500";
-
   const isNew = new Date(listing.createdAt).getTime() > NEW_LISTING_CUTOFF;
   const isHot = listing.metrics.monthlyVisitors >= HOT_VISITOR_THRESHOLD;
   const daysSinceUpdate = Math.floor(
@@ -68,118 +42,165 @@ export function ListingCard({ listing }: ListingCardProps) {
   );
   const isStale = daysSinceUpdate >= STALE_THRESHOLD_DAYS;
 
-  const gradient = CATEGORY_GRADIENTS[listing.category] ?? "from-zinc-800 to-zinc-900";
+  const accentClassName =
+    CATEGORY_ACCENT_CLASSES[listing.category] ?? "from-zinc-700/20 via-zinc-500/10 to-transparent";
+
+  const trustLabel = listing.ownershipVerified
+    ? listing.ownershipVerificationMethod === "repo"
+      ? "Repository verified"
+      : listing.ownershipVerificationMethod === "domain"
+        ? "Domain verified"
+        : "Manually reviewed"
+    : "Trust check pending";
+
+  const summaryBadges: Array<{ key: string; className: string; label: React.ReactNode }> = [];
+  if (listing.featured) {
+    summaryBadges.push({
+      key: "featured",
+      className: "border-amber-400/25 bg-amber-400/10 text-amber-200",
+      label: "Featured",
+    });
+  }
+  if (listing.status === "under_offer") {
+    summaryBadges.push({
+      key: "under-offer",
+      className: "border-blue-400/20 bg-blue-400/10 text-blue-200",
+      label: "Under offer",
+    });
+  } else if (isHot) {
+    summaryBadges.push({
+      key: "hot",
+      className: "border-orange-400/20 bg-orange-400/10 text-orange-200",
+      label: (
+        <>
+          <Flame className="mr-1 h-3 w-3" />
+          Hot
+        </>
+      ),
+    });
+  } else if (isNew) {
+    summaryBadges.push({
+      key: "new",
+      className: "border-emerald-400/20 bg-emerald-400/10 text-emerald-200",
+      label: (
+        <>
+          <Sparkles className="mr-1 h-3 w-3" />
+          New
+        </>
+      ),
+    });
+  }
 
   return (
     <TiltCardShell className="relative" overlayClassName="rounded-[28px]">
       <Link href={`/listing/${listing.id}`} className="block h-full">
-        <Card className="card-hover flex h-full min-h-[396px] cursor-pointer flex-col gap-0 overflow-hidden rounded-[28px] border-white/10 bg-[#0b1120]/95 py-0">
-          <div className={`h-1.5 w-full bg-gradient-to-r ${gradient}`} />
-          <CardContent className="flex flex-1 flex-col p-0">
-            <div className="border-b border-white/[0.08] p-5">
-              <div className="flex items-start justify-between gap-3 pr-10">
-                <div>
-                  <p className="eyebrow">{CATEGORY_LABELS[listing.category]}</p>
-                  <h3 className="mt-4 line-clamp-2 text-2xl font-semibold leading-tight text-zinc-50">
-                    {listing.title}
-                  </h3>
-                </div>
-                <ArrowUpRight className="mt-1 h-4 w-4 shrink-0 text-slate-500" />
+        <Card className="card-hover flex h-full min-h-[520px] cursor-pointer flex-col gap-0 overflow-hidden rounded-[28px] border-white/10 bg-[#0b1120]/95 py-0">
+          <CardContent className="flex flex-1 flex-col p-5">
+            <ProductPreviewPanel
+              className="h-[188px]"
+              imageSrc={listing.screenshots[0] ?? null}
+              eyebrow={CATEGORY_LABELS[listing.category]}
+              accentClassName={accentClassName}
+              stats={[
+                { label: "Ask", value: formatPrice(listing.askingPrice) },
+                { label: "MRR", value: formatPrice(listing.metrics.mrr) },
+                { label: "Visitors", value: formatNumber(listing.metrics.monthlyVisitors) },
+                { label: "Users", value: formatNumber(listing.metrics.registeredUsers) },
+              ]}
+              footer={listing.contactMode === "proposal" ? "Proposal gate enabled" : "Direct unlock flow"}
+            />
+
+            <div className="mt-5 flex items-start justify-between gap-3 pr-10">
+              <div>
+                <p className="text-xs uppercase tracking-[0.26em] text-slate-500">
+                  {CATEGORY_LABELS[listing.category]}  /  {trustLabel}
+                </p>
+                <h3 className="mt-3 line-clamp-2 text-[1.8rem] font-semibold leading-tight text-zinc-50">
+                  {listing.title}
+                </h3>
               </div>
-              <p className="mt-3 line-clamp-3 min-h-[72px] text-sm leading-6 text-slate-300">{listing.pitch}</p>
-              <div className="mt-4 flex flex-wrap gap-2">
-                {listing.featured && (
-                  <Badge className="border-amber-400/25 bg-amber-400/10 text-amber-200">Featured</Badge>
-                )}
-                {listing.status === "under_offer" && (
-                  <Badge className="border-blue-400/20 bg-blue-400/10 text-blue-200">Under offer</Badge>
-                )}
-                {listing.contactMode === "proposal" && (
-                  <Badge className="border-sky-400/20 bg-sky-400/10 text-sky-200">Proposal gate</Badge>
-                )}
-                {isNew && listing.status !== "under_offer" && (
-                  <Badge className="border-emerald-400/20 bg-emerald-400/10 text-emerald-200">
-                    <Sparkles className="mr-1 h-3 w-3" />
-                    New
-                  </Badge>
-                )}
-                {isHot && (
-                  <Badge className="border-orange-400/20 bg-orange-400/10 text-orange-200">
-                    <Flame className="mr-1 h-3 w-3" />
-                    Hot
-                  </Badge>
-                )}
-              </div>
+              <ArrowUpRight className="mt-1 h-4 w-4 shrink-0 text-slate-500" />
             </div>
 
-            <div className="grid grid-cols-2 gap-px border-b border-white/[0.08] bg-white/[0.08]">
-              <div className="bg-[#0b1120] p-4">
-                <p className="eyebrow">MRR</p>
-                <div className="mt-2 flex items-center gap-2">
-                  <TrendIcon className={`h-3.5 w-3.5 ${trendColor}`} />
-                  <p className="text-lg font-semibold text-zinc-50">{formatPrice(listing.metrics.mrr)}</p>
-                </div>
-              </div>
-              <div className="bg-[#0b1120] p-4">
-                <p className="eyebrow">Visitors</p>
+            <p className="mt-3 line-clamp-3 min-h-[72px] text-sm leading-6 text-slate-300">{listing.pitch}</p>
+
+            <div className="mt-4 flex min-h-6 flex-wrap gap-2">
+              {summaryBadges.map((badge) => (
+                <Badge key={badge.key} className={badge.className}>
+                  {badge.label}
+                </Badge>
+              ))}
+            </div>
+
+            <div className="mt-5 grid grid-cols-2 gap-3">
+              <div className="rounded-[20px] border border-white/10 bg-white/[0.04] p-4">
+                <p className="eyebrow">Monthly profit</p>
                 <p className="mt-2 text-lg font-semibold text-zinc-50">
-                  {formatNumber(listing.metrics.monthlyVisitors)}
+                  {formatPrice(listing.metrics.monthlyProfit)}
                 </p>
               </div>
-              <div className="bg-[#0b1120] p-4">
-                <p className="eyebrow">Users</p>
-                <p className="mt-2 text-lg font-semibold text-zinc-50">
-                  {formatNumber(listing.metrics.registeredUsers)}
-                </p>
+              <div className="rounded-[20px] border border-white/10 bg-white/[0.04] p-4">
+                <p className="eyebrow">Product age</p>
+                <p className="mt-2 text-lg font-semibold text-zinc-50">{listing.metrics.age}</p>
               </div>
-              <div className="bg-[#0b1120] p-4">
-                <p className="eyebrow">Contact</p>
+              <div className="rounded-[20px] border border-white/10 bg-white/[0.04] p-4">
+                <p className="eyebrow">Buyer flow</p>
                 <p className="mt-2 text-sm font-medium text-zinc-50">
                   {listing.contactMode === "proposal" ? "Seller screens buyers" : "Unlock and message"}
                 </p>
               </div>
+              <div className="rounded-[20px] border border-white/10 bg-white/[0.04] p-4">
+                <p className="eyebrow">Assets included</p>
+                <p className="mt-2 text-lg font-semibold text-zinc-50">{listing.assetsIncluded.length}</p>
+              </div>
             </div>
 
-            <div className="flex flex-1 flex-col p-5">
-              <div className="min-h-[48px]">
-                {listing.ownershipVerified ? (
-                  <span className="inline-flex items-center gap-1 rounded-full border border-emerald-400/25 bg-emerald-400/10 px-2.5 py-1 text-[11px] font-medium text-emerald-200">
-                    <ShieldCheck className="h-3 w-3" />
-                    {listing.ownershipVerificationMethod === "repo"
-                      ? "Repository ownership verified"
-                      : listing.ownershipVerificationMethod === "domain"
-                        ? "Domain ownership verified"
-                        : "Manually reviewed by SideFlip"}
-                  </span>
-                ) : (
-                  <span className="inline-flex items-center gap-1 rounded-full border border-amber-400/25 bg-amber-400/10 px-2.5 py-1 text-[11px] font-medium text-amber-200">
-                    Trust check pending
-                  </span>
-                )}
-              </div>
-
-              <div className="mt-4 min-h-6">
-                <TechStackBadges stack={listing.techStack} max={4} />
-              </div>
-
-              <div className="mt-auto flex items-end justify-between gap-4 pt-5">
+            <div className="mt-4 rounded-[22px] border border-white/10 bg-white/[0.03] p-4">
+              <div className="grid grid-cols-1 gap-4 text-sm text-slate-300 sm:grid-cols-3">
                 <div>
-                  <p className="eyebrow">Ask</p>
-                  <p className="mt-2 text-2xl font-semibold text-amber-200">{formatPrice(listing.askingPrice)}</p>
-                </div>
-                <div className="text-right">
-                  {listing.openToOffers ? (
-                    <p className="inline-flex items-center gap-1 text-sm text-sky-200">
-                      <Handshake className="h-3.5 w-3.5" />
-                      Open to offers
-                    </p>
-                  ) : (
-                    <p className="text-sm text-slate-400">Fixed ask</p>
-                  )}
-                  <p className="mt-2 text-xs text-slate-500">
-                    {isStale ? `Last updated ${daysSinceUpdate}d ago` : "Recently refreshed"}
+                  <p className="eyebrow">Trust</p>
+                  <p className="mt-2 inline-flex items-center gap-1 text-sm text-zinc-100">
+                    <ShieldCheck className="h-3.5 w-3.5 text-emerald-300" />
+                    {trustLabel}
                   </p>
                 </div>
+                <div>
+                  <p className="eyebrow">Contact mode</p>
+                  <p className="mt-2 inline-flex items-center gap-1 text-sm text-zinc-100">
+                    <MessageSquareText className="h-3.5 w-3.5 text-sky-300" />
+                    {listing.contactMode === "proposal" ? "Offer first, reveal later" : "Instant unlock"}
+                  </p>
+                </div>
+                <div>
+                  <p className="eyebrow">Freshness</p>
+                  <p className="mt-2 inline-flex items-center gap-1 text-sm text-zinc-100">
+                    <Clock3 className="h-3.5 w-3.5 text-amber-300" />
+                    {isStale ? `${daysSinceUpdate}d since last refresh` : "Recently refreshed"}
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div className="mt-4 min-h-6">
+              <TechStackBadges stack={listing.techStack} max={3} />
+            </div>
+
+            <div className="mt-auto flex items-end justify-between gap-4 pt-5">
+              <div>
+                <p className="eyebrow">Acquisition thesis</p>
+                <p className="mt-2 text-sm leading-6 text-slate-300">
+                  Revenue, traffic, and buyer flow are visible before you spend connects.
+                </p>
+              </div>
+              <div className="text-right">
+                {listing.openToOffers ? (
+                  <p className="inline-flex items-center gap-1 text-sm text-sky-200">
+                    <Handshake className="h-3.5 w-3.5" />
+                    Open to offers
+                  </p>
+                ) : (
+                  <p className="text-sm text-slate-400">Fixed ask</p>
+                )}
               </div>
             </div>
           </CardContent>

--- a/src/components/listing/listing-grid.tsx
+++ b/src/components/listing/listing-grid.tsx
@@ -4,7 +4,6 @@ import { Listing } from "@/types/listing";
 import { ListingCard } from "./listing-card";
 import { motion, useReducedMotion } from "framer-motion";
 import { useMotionProfile } from "@/components/shared/use-motion-profile";
-import { cn } from "@/lib/utils";
 
 interface ListingGridProps {
   listings: Listing[];
@@ -44,10 +43,7 @@ export function ListingGrid({ listings }: ListingGridProps) {
       {listings.map((listing) => (
         <motion.div
           key={listing.id}
-          className={cn(
-            "h-full",
-            listings.length > 2 && listing === listings[0] ? "lg:col-span-2" : ""
-          )}
+          className="h-full"
           variants={
             disableHeavyMotion
               ? undefined

--- a/src/components/listing/listing-spotlight-rail.tsx
+++ b/src/components/listing/listing-spotlight-rail.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import Link from "next/link";
+import { ArrowUpRight, Handshake, ShieldCheck } from "lucide-react";
+import { Listing } from "@/types/listing";
+import { CATEGORY_ACCENT_CLASSES, CATEGORY_LABELS } from "@/lib/constants";
+import { formatNumber, formatPrice } from "@/lib/formatting";
+import { ProductPreviewPanel } from "@/components/shared/product-preview-panel";
+
+interface ListingSpotlightRailProps {
+  listings: Listing[];
+}
+
+export function ListingSpotlightRail({ listings }: ListingSpotlightRailProps) {
+  if (listings.length === 0) return null;
+
+  return (
+    <section className="surface-panel mb-8 rounded-[32px] p-5 sm:p-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="eyebrow">Featured desk</p>
+          <h2 className="mt-2 text-2xl font-semibold text-zinc-50">Verified acquisition leads</h2>
+          <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
+            A tighter shortlist of projects with better traction, stronger trust signals, or active buyer flow.
+          </p>
+        </div>
+        <div className="rounded-full border border-white/10 bg-white/[0.04] px-3 py-1.5 text-sm text-slate-300">
+          {listings.length} in spotlight
+        </div>
+      </div>
+
+      <div className="mt-5 flex snap-x gap-4 overflow-x-auto pb-1">
+        {listings.map((listing) => (
+          <Link
+            key={listing.id}
+            href={`/listing/${listing.id}`}
+            className="group min-w-[290px] max-w-[320px] flex-1 snap-start rounded-[28px] border border-white/10 bg-[#0a1220]/88 p-3 transition-colors hover:border-sky-400/30"
+          >
+            <ProductPreviewPanel
+              className="h-[168px]"
+              imageSrc={listing.screenshots[0] ?? null}
+              eyebrow={CATEGORY_LABELS[listing.category]}
+              accentClassName={CATEGORY_ACCENT_CLASSES[listing.category] ?? "from-slate-500/25 to-slate-400/5"}
+              stats={[
+                { label: "Ask", value: formatPrice(listing.askingPrice) },
+                { label: "MRR", value: formatPrice(listing.metrics.mrr) },
+                { label: "Users", value: formatNumber(listing.metrics.registeredUsers) },
+                { label: "Flow", value: listing.contactMode === "proposal" ? "Proposal" : "Direct" },
+              ]}
+              footer={listing.ownershipVerified ? "Ownership verified" : "Trust review pending"}
+            />
+
+            <div className="mt-4 flex items-start justify-between gap-3">
+              <div>
+                <h3 className="line-clamp-2 text-lg font-semibold text-zinc-50">{listing.title}</h3>
+                <p className="mt-2 line-clamp-2 text-sm leading-6 text-slate-400">{listing.pitch}</p>
+              </div>
+              <ArrowUpRight className="mt-1 h-4 w-4 shrink-0 text-slate-500 transition-colors group-hover:text-sky-200" />
+            </div>
+
+            <div className="mt-4 flex items-center justify-between gap-3 text-sm">
+              <span className="inline-flex items-center gap-1 text-slate-300">
+                {listing.ownershipVerified ? <ShieldCheck className="h-3.5 w-3.5 text-emerald-300" /> : null}
+                {listing.ownershipVerified ? "Verified" : "Pending review"}
+              </span>
+              <span className="inline-flex items-center gap-1 text-slate-300">
+                <Handshake className="h-3.5 w-3.5 text-sky-300" />
+                {listing.openToOffers ? "Open to offers" : "Fixed ask"}
+              </span>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/shared/page-header.tsx
+++ b/src/components/shared/page-header.tsx
@@ -1,12 +1,13 @@
 interface PageHeaderProps {
   title: string;
   description?: string;
+  eyebrow?: string;
 }
 
-export function PageHeader({ title, description }: PageHeaderProps) {
+export function PageHeader({ title, description, eyebrow = "SideFlip" }: PageHeaderProps) {
   return (
     <div className="mb-8 max-w-3xl">
-      <p className="eyebrow">SideFlip</p>
+      <p className="eyebrow">{eyebrow}</p>
       <h1 className="mt-3 text-4xl font-semibold text-zinc-50 sm:text-5xl">{title}</h1>
       {description && <p className="mt-3 max-w-2xl text-[15px] leading-7 text-slate-400">{description}</p>}
     </div>

--- a/src/components/shared/product-preview-panel.tsx
+++ b/src/components/shared/product-preview-panel.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface PreviewMetric {
+  label: string;
+  value: string;
+}
+
+interface ProductPreviewPanelProps {
+  eyebrow: string;
+  accentClassName: string;
+  stats: PreviewMetric[];
+  footer: string;
+  imageSrc?: string | null;
+  className?: string;
+}
+
+export function ProductPreviewPanel({
+  eyebrow,
+  accentClassName,
+  stats,
+  footer,
+  imageSrc,
+  className,
+}: ProductPreviewPanelProps) {
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden rounded-[24px] border border-white/10 bg-[#07101e] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]",
+        className
+      )}
+    >
+      <div className={cn("absolute inset-0 bg-gradient-to-br", accentClassName)} />
+      {imageSrc ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={imageSrc}
+          alt=""
+          className="absolute inset-0 h-full w-full object-cover opacity-30"
+          loading="lazy"
+        />
+      ) : (
+        <div className="absolute inset-0 opacity-90">
+          <div className="absolute inset-0 bg-[linear-gradient(transparent_0,transparent_23px,rgba(255,255,255,0.03)_24px),linear-gradient(90deg,transparent_0,transparent_23px,rgba(255,255,255,0.03)_24px)] bg-[length:24px_24px]" />
+          <div className="absolute left-6 top-6 h-24 w-[42%] rounded-[20px] border border-white/12 bg-white/[0.06] shadow-[0_18px_44px_rgba(2,8,23,0.34)]" />
+          <div className="absolute right-6 top-10 h-16 w-[30%] rounded-[18px] border border-white/12 bg-white/[0.05]" />
+          <div className="absolute bottom-7 left-6 right-6 h-20 rounded-[22px] border border-white/12 bg-white/[0.05]" />
+          <div className="absolute bottom-12 left-10 h-2.5 w-[52%] rounded-full bg-white/12" />
+          <div className="absolute bottom-12 left-10 h-2.5 w-[30%] rounded-full bg-white/30" />
+          <div className="absolute bottom-7 left-10 flex gap-2">
+            <span className="h-2.5 w-12 rounded-full bg-white/12" />
+            <span className="h-2.5 w-16 rounded-full bg-white/10" />
+            <span className="h-2.5 w-9 rounded-full bg-white/8" />
+          </div>
+        </div>
+      )}
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(255,255,255,0.16),transparent_30%)]" />
+      <div className="absolute inset-0 bg-gradient-to-t from-[#040915] via-[#07101ee6] to-[#07101e4d]" />
+
+      <div className="relative flex h-full flex-col justify-between p-4">
+        <div className="flex items-start justify-between gap-3">
+          <span className="eyebrow text-[11px] tracking-[0.38em] text-slate-300/85">{eyebrow}</span>
+          <div className="rounded-full border border-white/12 bg-black/25 px-2 py-1 text-[10px] font-medium text-slate-300/80">
+            Live surface
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2">
+          {stats.slice(0, 4).map((stat) => (
+            <div
+              key={`${stat.label}-${stat.value}`}
+              className="rounded-[16px] border border-white/10 bg-black/28 px-3 py-2 shadow-[inset_0_1px_0_rgba(255,255,255,0.03)] backdrop-blur-sm"
+            >
+              <p className="text-[10px] uppercase tracking-[0.28em] text-slate-400">{stat.label}</p>
+              <p className="mt-1 text-sm font-semibold text-zinc-50">{stat.value}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-3 inline-flex w-fit rounded-full border border-white/10 bg-black/25 px-3 py-1.5 text-[11px] font-medium text-slate-300">
+          {footer}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,6 +18,17 @@ export const CATEGORY_LABELS: Record<string, string> = {
   "template-theme": "Templates & Themes",
 };
 
+export const CATEGORY_ACCENT_CLASSES: Record<string, string> = {
+  saas: "from-blue-500/30 via-sky-400/18 to-cyan-300/10",
+  "mobile-app": "from-sky-500/30 via-cyan-400/18 to-teal-300/10",
+  "chrome-extension": "from-indigo-500/30 via-blue-400/18 to-sky-300/10",
+  domain: "from-emerald-500/28 via-lime-400/18 to-amber-300/10",
+  "open-source": "from-orange-500/28 via-amber-400/18 to-yellow-300/10",
+  "bot-automation": "from-cyan-500/28 via-teal-400/18 to-emerald-300/10",
+  api: "from-rose-500/28 via-orange-400/18 to-amber-300/10",
+  "template-theme": "from-amber-500/28 via-yellow-400/18 to-sky-300/10",
+};
+
 export const CATEGORY_ICONS: Record<string, string> = {
   saas: "Cloud",
   "mobile-app": "Smartphone",


### PR DESCRIPTION
## Summary
- remove the oversized first-card treatment from browse and beta grids
- add media-driven preview panels and spotlight rails for browse and beta
- tighten card hierarchy and give browse and beta distinct page framing

## Validation
- npm run lint
- npm test
- npm run build