### PR TITLE
Improve public page performance

### DIFF
--- a/src/components/home/hero-aurora.tsx
+++ b/src/components/home/hero-aurora.tsx
@@ -1,72 +1,29 @@
-"use client";
-
-import { motion } from "framer-motion";
-import { useMotionProfile } from "@/components/shared/use-motion-profile";
-
 export function HeroAurora() {
-  const { prefersReducedMotion, isMobile } = useMotionProfile();
-
-  if (prefersReducedMotion) {
-    return (
-      <>
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_18%,rgba(59,130,246,0.2),transparent_45%),radial-gradient(circle_at_82%_24%,rgba(14,165,233,0.18),transparent_42%),radial-gradient(circle_at_65%_78%,rgba(251,191,36,0.14),transparent_48%)]"
-        />
-        <div
-          aria-hidden
-          className="pointer-events-none absolute inset-0 opacity-[0.045]"
-          style={{
-            backgroundImage:
-              "radial-gradient(rgba(255,255,255,0.8) 0.45px, transparent 0.45px)",
-            backgroundSize: "3px 3px",
-          }}
-        />
-      </>
-    );
-  }
-
-  if (isMobile) {
-    return (
-      <motion.div
-        aria-hidden
-        className="pointer-events-none absolute left-[-24%] top-[-28%] h-[420px] w-[420px] rounded-full bg-blue-500/24 blur-[105px]"
-        animate={{ x: [0, 40, 10, 0], y: [0, 36, 12, 0], scale: [1, 1.05, 0.98, 1] }}
-        transition={{ duration: 20, repeat: Number.POSITIVE_INFINITY, ease: "easeInOut" }}
-      />
-    );
-  }
-
   return (
     <>
-      <motion.div
+      <div
         aria-hidden
-        className="pointer-events-none absolute -left-24 top-[-28%] h-[520px] w-[520px] rounded-full bg-blue-500/30 blur-[120px]"
-        animate={{ x: [0, 80, 25, 0], y: [0, 55, 20, 0], scale: [1, 1.08, 0.98, 1] }}
-        transition={{ duration: 24, repeat: Number.POSITIVE_INFINITY, ease: "easeInOut" }}
+        className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_18%_18%,rgba(59,130,246,0.2),transparent_42%),radial-gradient(circle_at_82%_24%,rgba(14,165,233,0.16),transparent_38%),radial-gradient(circle_at_64%_78%,rgba(251,191,36,0.12),transparent_44%)]"
       />
-      <motion.div
+      <div
         aria-hidden
-        className="pointer-events-none absolute right-[-12%] top-[8%] h-[480px] w-[480px] rounded-full bg-sky-400/20 blur-[110px]"
-        animate={{ x: [0, -70, -20, 0], y: [0, 80, 30, 0], scale: [1, 1.1, 1, 1] }}
-        transition={{ duration: 26, repeat: Number.POSITIVE_INFINITY, ease: "easeInOut", delay: 1.2 }}
+        className="pointer-events-none absolute -left-24 top-[-28%] h-[520px] w-[520px] rounded-full bg-blue-500/24 blur-[120px]"
       />
-      <motion.div
+      <div
         aria-hidden
-        className="pointer-events-none absolute bottom-[-34%] left-[30%] h-[540px] w-[540px] rounded-full bg-amber-400/14 blur-[130px]"
-        animate={{ x: [0, 55, -30, 0], y: [0, -40, -70, 0], scale: [1.02, 0.96, 1.08, 1.02] }}
-        transition={{ duration: 28, repeat: Number.POSITIVE_INFINITY, ease: "easeInOut", delay: 0.6 }}
+        className="pointer-events-none absolute right-[-12%] top-[8%] h-[420px] w-[420px] rounded-full bg-sky-400/14 blur-[110px]"
       />
-      <motion.div
+      <div
         aria-hidden
-        className="pointer-events-none absolute inset-0 opacity-[0.055] mix-blend-soft-light"
+        className="pointer-events-none absolute bottom-[-30%] left-[28%] h-[460px] w-[460px] rounded-full bg-amber-400/10 blur-[120px]"
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-[0.045] mix-blend-soft-light"
         style={{
-          backgroundImage:
-            "radial-gradient(rgba(255,255,255,0.85) 0.45px, transparent 0.45px)",
+          backgroundImage: "radial-gradient(rgba(255,255,255,0.85) 0.45px, transparent 0.45px)",
           backgroundSize: "3px 3px",
         }}
-        animate={{ x: [0, 26, -18, 0], y: [0, -18, 22, 0] }}
-        transition={{ duration: 30, repeat: Number.POSITIVE_INFINITY, ease: "linear" }}
       />
     </>
   );

--- a/src/components/home/hero-client.tsx
+++ b/src/components/home/hero-client.tsx
@@ -1,13 +1,8 @@
-"use client";
-
 import Link from "next/link";
-import { motion, useMotionTemplate, useMotionValue, useReducedMotion, useScroll, useTransform } from "framer-motion";
 import { ArrowRight, BadgeCheck, ChartNoAxesCombined, Handshake, ShieldCheck, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { formatPrice } from "@/lib/formatting";
 import { AnimatedCount } from "./animated-count";
-import { MagneticButton } from "./magnetic-button";
-import type { MouseEvent } from "react";
 import type { Listing } from "@/types/listing";
 import { CATEGORY_LABELS } from "@/lib/constants";
 
@@ -20,8 +15,6 @@ interface HeroClientProps {
   leadListing: Listing | null;
 }
 
-const SPOTLIGHT_OVERSCAN = 220;
-
 export function HeroClient({
   listingsCount,
   betaTestsCount,
@@ -30,56 +23,12 @@ export function HeroClient({
   proposalCount,
   leadListing,
 }: HeroClientProps) {
-  const reduceMotion = useReducedMotion();
-  const { scrollYProgress } = useScroll();
-
-  const titleY = useTransform(scrollYProgress, [0, 0.28], [0, 40]);
-  const titleOpacity = useTransform(scrollYProgress, [0, 0.2, 0.34], [1, 1, 0.55]);
-  const ctaY = useTransform(scrollYProgress, [0, 0.25], [0, 22]);
-  const ctaOpacity = useTransform(scrollYProgress, [0, 0.24, 0.36], [1, 1, 0.65]);
-
-  const mouseX = useMotionValue(-1000);
-  const mouseY = useMotionValue(-1000);
-  const spotlightBg = useMotionTemplate`radial-gradient(340px circle at ${mouseX}px ${mouseY}px, rgba(59,130,246,0.22), rgba(251,191,36,0.1) 42%, transparent 74%)`;
-
-  const handlePointerMove = (event: MouseEvent<HTMLDivElement>) => {
-    if (reduceMotion) return;
-    if (window.innerWidth < 1024) return;
-    const rect = event.currentTarget.getBoundingClientRect();
-    mouseX.set(event.clientX - rect.left + SPOTLIGHT_OVERSCAN);
-    mouseY.set(event.clientY - rect.top + SPOTLIGHT_OVERSCAN);
-  };
-
-  const handlePointerLeave = () => {
-    mouseX.set(-1000);
-    mouseY.set(-1000);
-  };
-
   return (
-    <div
-      className="relative z-10 w-full py-24 sm:py-28"
-      onMouseMove={handlePointerMove}
-      onMouseLeave={handlePointerLeave}
-    >
-      {!reduceMotion && (
-        <motion.div
-          aria-hidden
-          className="pointer-events-none absolute z-0 hidden lg:block"
-          style={{
-            top: -SPOTLIGHT_OVERSCAN,
-            right: -SPOTLIGHT_OVERSCAN,
-            bottom: -SPOTLIGHT_OVERSCAN,
-            left: -SPOTLIGHT_OVERSCAN,
-            background: spotlightBg,
-            filter: "blur(8px)",
-          }}
-        />
-      )}
-
+    <div className="relative z-10 w-full py-24 sm:py-28">
       <div className="relative z-10 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="grid gap-10 lg:grid-cols-[minmax(0,1.08fr)_minmax(320px,420px)] lg:items-end">
-          <motion.div style={reduceMotion ? undefined : { y: titleY, opacity: titleOpacity }}>
-            <div className="animate-float-slow mb-6 inline-flex items-center gap-2 rounded-full border border-sky-500/20 bg-sky-500/8 px-4 py-1.5 text-sm text-sky-200">
+          <div>
+            <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-sky-500/20 bg-sky-500/8 px-4 py-1.5 text-sm text-sky-200">
               <Zap className="h-3.5 w-3.5" />
               Curated marketplace for indie operators
             </div>
@@ -107,30 +56,23 @@ export function HeroClient({
               </span>
             </div>
 
-            <motion.div
-              className="mt-10 flex flex-col gap-3 sm:flex-row"
-              style={reduceMotion ? undefined : { y: ctaY, opacity: ctaOpacity }}
-            >
-              <MagneticButton className="inline-block">
-                <Link href="/browse">
-                  <Button size="lg" className="min-w-[190px] bg-blue-600 text-white hover:bg-blue-500">
-                    Browse Listings
-                    <ArrowRight className="ml-2 h-4 w-4" />
-                  </Button>
-                </Link>
-              </MagneticButton>
-              <MagneticButton className="inline-block">
-                <Link href="/create">
-                  <Button
-                    size="lg"
-                    variant="outline"
-                    className="min-w-[190px] border-white/[0.12] bg-white/5 text-slate-200 hover:border-amber-300/35 hover:bg-amber-300/10"
-                  >
-                    List Your Product
-                  </Button>
-                </Link>
-              </MagneticButton>
-            </motion.div>
+            <div className="mt-10 flex flex-col gap-3 sm:flex-row">
+              <Link href="/browse">
+                <Button size="lg" className="min-w-[190px] bg-blue-600 text-white hover:bg-blue-500">
+                  Browse Listings
+                  <ArrowRight className="ml-2 h-4 w-4" />
+                </Button>
+              </Link>
+              <Link href="/create">
+                <Button
+                  size="lg"
+                  variant="outline"
+                  className="min-w-[190px] border-white/[0.12] bg-white/5 text-slate-200 hover:border-amber-300/35 hover:bg-amber-300/10"
+                >
+                  List Your Product
+                </Button>
+              </Link>
+            </div>
 
             <div className="mt-12 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
               <div className="metric-panel rounded-2xl p-4">
@@ -160,14 +102,9 @@ export function HeroClient({
                 <p className="mt-1 text-sm text-slate-400">Used only for seller unlocks</p>
               </div>
             </div>
-          </motion.div>
+          </div>
 
-          <motion.div
-            className="surface-panel rounded-[28px] p-5 sm:p-6"
-            initial={reduceMotion ? undefined : { opacity: 0, x: 16, y: 12 }}
-            animate={reduceMotion ? undefined : { opacity: 1, x: 0, y: 0 }}
-            transition={{ duration: 0.45, ease: [0.22, 1, 0.36, 1], delay: reduceMotion ? 0 : 0.08 }}
-          >
+          <div className="surface-panel rounded-[28px] p-5 sm:p-6">
             <div className="flex items-center justify-between">
               <div>
                 <p className="eyebrow">Live market snapshot</p>
@@ -245,7 +182,7 @@ export function HeroClient({
             <p className="mt-5 text-sm leading-6 text-slate-400">
               Beta testing is free to post with rewards. For cash-reward beta tests, SideFlip deducts a 5% platform fee while paying testers.
             </p>
-          </motion.div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/home/hero.tsx
+++ b/src/components/home/hero.tsx
@@ -1,6 +1,5 @@
 import { getListings } from "@/lib/db/listings";
 import { getActiveBetaTests } from "@/lib/db/beta-tests";
-import { HeroParallaxBackdrop } from "./hero-parallax-backdrop";
 import { HeroAurora } from "./hero-aurora";
 import { HeroClient } from "./hero-client";
 
@@ -20,7 +19,6 @@ export async function Hero() {
   return (
     <section className="gradient-hero relative overflow-hidden">
       <HeroAurora />
-      <HeroParallaxBackdrop />
       <HeroClient
         listingsCount={listings.length}
         betaTestsCount={betaTests.length}

--- a/src/components/layout/navbar-wrapper.tsx
+++ b/src/components/layout/navbar-wrapper.tsx
@@ -1,23 +1,5 @@
-import { auth } from "@clerk/nextjs/server";
-import { getConnectsBalance } from "@/lib/db/connects";
-import { getUnreadUserNotificationCount, getUserNotifications } from "@/lib/db/notifications";
 import { Navbar } from "./navbar";
 
 export async function NavbarWrapper() {
-  const { userId } = await auth();
-  if (!userId) return <Navbar connectsBalance={null} unreadNotifications={0} notifications={[]} />;
-
-  const [connectsBalance, unreadNotifications, notifications] = await Promise.all([
-    getConnectsBalance(userId),
-    getUnreadUserNotificationCount(userId),
-    getUserNotifications(userId, 12),
-  ]);
-
-  return (
-    <Navbar
-      connectsBalance={connectsBalance}
-      unreadNotifications={unreadNotifications}
-      notifications={notifications}
-    />
-  );
+  return <Navbar connectsBalance={null} unreadNotifications={0} notifications={[]} />;
 }

--- a/src/components/layout/navbar.tsx
+++ b/src/components/layout/navbar.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Bell, CheckCheck, Loader2, Menu, Rocket, X, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { NAV_LINKS, SITE_NAME } from "@/lib/constants";
 import { AnimatePresence, motion } from "framer-motion";
 import { usePathname } from "next/navigation";
 import {
+  getNavbarMetaAction,
   getNotificationsSnapshotAction,
   markAllNotificationsReadAction,
 } from "./notification-actions";
@@ -17,6 +18,7 @@ import {
   SignInButton,
   SignUpButton,
   UserButton,
+  useAuth,
 } from "@clerk/nextjs";
 import type { UserNotificationItem } from "@/types/notification";
 
@@ -38,13 +40,20 @@ function formatNotificationTime(input: string): string {
 }
 
 export function Navbar({ connectsBalance, unreadNotifications, notifications }: NavbarProps) {
+  const { isLoaded, userId } = useAuth();
   const [mobileOpen, setMobileOpen] = useState(false);
   const [notificationsOpen, setNotificationsOpen] = useState(false);
   const [loadingNotifications, setLoadingNotifications] = useState(false);
   const [markingRead, setMarkingRead] = useState(false);
+  const [localConnectsBalance, setLocalConnectsBalance] = useState(connectsBalance ?? null);
   const [localUnreadCount, setLocalUnreadCount] = useState(unreadNotifications);
   const [localNotifications, setLocalNotifications] = useState(notifications);
+  const [localStateUserId, setLocalStateUserId] = useState<string | null>(null);
   const pathname = usePathname();
+  const isLocalStateFresh = Boolean(userId) && localStateUserId === userId;
+  const resolvedConnectsBalance = isLocalStateFresh ? localConnectsBalance : connectsBalance ?? null;
+  const resolvedUnreadCount = isLocalStateFresh ? localUnreadCount : unreadNotifications;
+  const resolvedNotifications = isLocalStateFresh ? localNotifications : notifications;
 
   const isActive = (href: string) =>
     pathname === href || (href !== "/" && pathname.startsWith(href));
@@ -59,22 +68,52 @@ export function Navbar({ connectsBalance, unreadNotifications, notifications }: 
     const snapshot = await getNotificationsSnapshotAction();
     setLoadingNotifications(false);
     if (snapshot.error) return;
+    setLocalStateUserId(userId ?? null);
     setLocalUnreadCount(snapshot.unread);
     setLocalNotifications(snapshot.notifications);
   };
 
   const handleMarkAllRead = async () => {
-    if (markingRead || localUnreadCount === 0) return;
+    if (markingRead || resolvedUnreadCount === 0) return;
     setMarkingRead(true);
     const result = await markAllNotificationsReadAction();
     setMarkingRead(false);
     if (result.error) return;
     const nowIso = new Date().toISOString();
+    setLocalStateUserId(userId ?? null);
     setLocalUnreadCount(0);
     setLocalNotifications((prev) =>
       prev.map((item) => ({ ...item, readAt: item.readAt ?? nowIso }))
     );
   };
+
+  useEffect(() => {
+    if (!isLoaded || !userId || localStateUserId === userId) return;
+
+    let cancelled = false;
+    const run = async () => {
+      const snapshot = await getNavbarMetaAction();
+      if (cancelled || snapshot.error) return;
+      setLocalStateUserId(userId);
+      setLocalConnectsBalance(snapshot.connectsBalance);
+      setLocalUnreadCount(snapshot.unread);
+    };
+
+    let clearScheduledRun = () => {};
+
+    if (typeof window !== "undefined" && "requestIdleCallback" in window) {
+      const idleHandle = window.requestIdleCallback(run, { timeout: 1200 });
+      clearScheduledRun = () => window.cancelIdleCallback(idleHandle);
+    } else {
+      const timeoutHandle = globalThis.setTimeout(run, 150);
+      clearScheduledRun = () => globalThis.clearTimeout(timeoutHandle);
+    }
+
+    return () => {
+      cancelled = true;
+      clearScheduledRun();
+    };
+  }, [isLoaded, localStateUserId, userId]);
 
   return (
     <nav className="sticky top-0 z-50 border-b border-white/10 bg-[#060a13]/80 backdrop-blur-md">
@@ -140,14 +179,14 @@ export function Navbar({ connectsBalance, unreadNotifications, notifications }: 
                 )}
               </Link>
             ))}
-            {connectsBalance != null && (
+            {resolvedConnectsBalance != null && (
               <Link
                 href="/connects"
                 className="inline-flex items-center gap-1 rounded-full border border-amber-300/25 bg-amber-300/10 px-2.5 py-1 text-xs font-medium text-amber-200 transition-colors hover:bg-amber-300/20"
                 title="Your Connects balance"
               >
                 <Zap className="h-3 w-3" />
-                {connectsBalance}
+                {resolvedConnectsBalance}
               </Link>
             )}
             <div className="relative">
@@ -158,9 +197,9 @@ export function Navbar({ connectsBalance, unreadNotifications, notifications }: 
                 title="Notifications"
               >
                 <Bell className="h-4 w-4" />
-                {localUnreadCount > 0 && (
+                {resolvedUnreadCount > 0 && (
                   <span className="absolute -right-1 -top-1 inline-flex min-h-4 min-w-4 items-center justify-center rounded-full bg-blue-600 px-1 text-[10px] font-semibold text-white">
-                    {localUnreadCount > 9 ? "9+" : localUnreadCount}
+                    {resolvedUnreadCount > 9 ? "9+" : resolvedUnreadCount}
                   </span>
                 )}
               </button>
@@ -178,7 +217,7 @@ export function Navbar({ connectsBalance, unreadNotifications, notifications }: 
                       <button
                         type="button"
                         onClick={handleMarkAllRead}
-                        disabled={markingRead || localUnreadCount === 0}
+                        disabled={markingRead || resolvedUnreadCount === 0}
                         className="inline-flex items-center gap-1 text-xs text-zinc-400 transition-colors hover:text-zinc-200 disabled:cursor-not-allowed disabled:opacity-40"
                       >
                         {markingRead ? (
@@ -193,13 +232,13 @@ export function Navbar({ connectsBalance, unreadNotifications, notifications }: 
                       <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3 text-sm text-zinc-500">
                         Loading...
                       </div>
-                    ) : localNotifications.length === 0 ? (
+                    ) : resolvedNotifications.length === 0 ? (
                       <div className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-3 text-sm text-zinc-500">
                         No notifications yet.
                       </div>
                     ) : (
                       <div className="max-h-96 space-y-1 overflow-y-auto">
-                        {localNotifications.map((item) => {
+                        {resolvedNotifications.map((item) => {
                           const content = (
                             <div className="flex items-start gap-2 rounded-lg border border-zinc-800 bg-zinc-900/50 px-3 py-2 transition-colors hover:border-zinc-700">
                               {!item.readAt ? (
@@ -322,22 +361,22 @@ export function Navbar({ connectsBalance, unreadNotifications, notifications }: 
                   </Link>
                 ))}
                 <div className="flex items-center justify-between py-2 text-sm">
-                  <span className="text-zinc-400">Notifications</span>
-                  <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-indigo-500/20 px-1.5 py-0.5 text-xs text-indigo-300">
-                    {localUnreadCount}
+                    <span className="text-zinc-400">Notifications</span>
+                    <span className="inline-flex min-w-5 items-center justify-center rounded-full bg-indigo-500/20 px-1.5 py-0.5 text-xs text-indigo-300">
+                    {resolvedUnreadCount}
                   </span>
                 </div>
                 <div className="flex items-center gap-3 py-2">
                   <UserButton />
                   <span className="text-sm text-zinc-400">My Account</span>
-                  {connectsBalance != null && (
+                  {resolvedConnectsBalance != null && (
                     <Link
                       href="/connects"
                       className="ml-auto inline-flex items-center gap-1 rounded-full border border-indigo-500/30 bg-indigo-500/10 px-2.5 py-1 text-xs font-medium text-indigo-300"
                       onClick={() => setMobileOpen(false)}
                     >
                       <Zap className="h-3 w-3" />
-                      {connectsBalance}
+                      {resolvedConnectsBalance}
                     </Link>
                   )}
                 </div>

--- a/src/components/layout/notification-actions.ts
+++ b/src/components/layout/notification-actions.ts
@@ -6,6 +6,7 @@ import {
   getUserNotifications,
   markAllUserNotificationsRead,
 } from "@/lib/db/notifications";
+import { getConnectsBalance } from "@/lib/db/connects";
 import { revalidatePath } from "next/cache";
 import { UserNotificationItem } from "@/types/notification";
 
@@ -23,6 +24,22 @@ export async function getNotificationsSnapshotAction(): Promise<{
   ]);
 
   return { unread, notifications };
+}
+
+export async function getNavbarMetaAction(): Promise<{
+  error?: string;
+  unread: number;
+  connectsBalance: number | null;
+}> {
+  const { userId } = await auth();
+  if (!userId) return { error: "Not authenticated", unread: 0, connectsBalance: null };
+
+  const [unread, connectsBalance] = await Promise.all([
+    getUnreadUserNotificationCount(userId),
+    getConnectsBalance(userId),
+  ]);
+
+  return { unread, connectsBalance };
 }
 
 export async function markAllNotificationsReadAction(): Promise<{

--- a/src/components/shared/product-preview-panel.tsx
+++ b/src/components/shared/product-preview-panel.tsx
@@ -39,6 +39,8 @@ export function ProductPreviewPanel({
           alt=""
           className="absolute inset-0 h-full w-full object-cover opacity-30"
           loading="lazy"
+          decoding="async"
+          fetchPriority="low"
         />
       ) : (
         <div className="absolute inset-0 opacity-90">

--- a/src/components/shared/tilt-card-shell.tsx
+++ b/src/components/shared/tilt-card-shell.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { motion, useMotionTemplate, useMotionValue, useSpring } from "framer-motion";
-import type { MouseEvent, ReactNode } from "react";
+import { motion } from "framer-motion";
+import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { useMotionProfile } from "./use-motion-profile";
 
@@ -14,69 +14,26 @@ interface TiltCardShellProps {
 export function TiltCardShell({ children, className, overlayClassName }: TiltCardShellProps) {
   const { prefersReducedMotion, isMobile } = useMotionProfile();
 
-  const enableTilt = !prefersReducedMotion && !isMobile;
   const enableLift = !prefersReducedMotion;
-
-  const rotateX = useMotionValue(0);
-  const rotateY = useMotionValue(0);
-  const lightX = useMotionValue(50);
-  const lightY = useMotionValue(50);
-
-  const springRotateX = useSpring(rotateX, { stiffness: 240, damping: 24, mass: 0.7 });
-  const springRotateY = useSpring(rotateY, { stiffness: 240, damping: 24, mass: 0.7 });
-  const cursorGlow = useMotionTemplate`radial-gradient(220px circle at ${lightX}% ${lightY}%, rgba(34,211,238,0.24), rgba(99,102,241,0.14) 38%, transparent 72%)`;
-
-  const handleMouseMove = (event: MouseEvent<HTMLDivElement>) => {
-    if (!enableTilt) return;
-    const rect = event.currentTarget.getBoundingClientRect();
-    const px = (event.clientX - rect.left) / rect.width;
-    const py = (event.clientY - rect.top) / rect.height;
-
-    lightX.set(px * 100);
-    lightY.set(py * 100);
-    rotateY.set((px - 0.5) * 9);
-    rotateX.set((0.5 - py) * 9);
-  };
-
-  const handleMouseLeave = () => {
-    rotateX.set(0);
-    rotateY.set(0);
-    lightX.set(50);
-    lightY.set(50);
-  };
 
   return (
     <motion.div
       className={cn("group relative h-full will-change-transform", className)}
-      style={
-        enableTilt
-          ? {
-              rotateX: springRotateX,
-              rotateY: springRotateY,
-              transformPerspective: 1100,
-              transformStyle: "preserve-3d",
-            }
-          : undefined
-      }
-      whileHover={enableLift ? (isMobile ? { y: -2 } : { y: -6, scale: 1.01 }) : undefined}
+      whileHover={enableLift ? (isMobile ? { y: -2 } : { y: -4, scale: 1.006 }) : undefined}
       transition={
         isMobile
           ? { duration: 0.18, ease: [0.22, 1, 0.36, 1] }
-          : { type: "spring", stiffness: 280, damping: 24, mass: 0.85 }
+          : { type: "spring", stiffness: 300, damping: 28, mass: 0.9 }
       }
-      onMouseMove={handleMouseMove}
-      onMouseLeave={handleMouseLeave}
     >
-      {enableTilt && (
-        <motion.div
-          aria-hidden
-          className={cn(
-            "pointer-events-none absolute inset-0 z-[1] opacity-0 transition-opacity duration-200 group-hover:opacity-100",
-            overlayClassName
-          )}
-          style={{ background: cursorGlow, mixBlendMode: "screen" }}
-        />
-      )}
+      <div
+        aria-hidden
+        className={cn(
+          "pointer-events-none absolute inset-0 z-[1] opacity-0 transition-opacity duration-200 group-hover:opacity-100",
+          overlayClassName,
+          "bg-[radial-gradient(circle_at_top,rgba(56,189,248,0.12),transparent_46%)]"
+        )}
+      />
       <div className="relative z-[2] h-full">{children}</div>
     </motion.div>
   );


### PR DESCRIPTION
## Summary
- lazy-load signed-in navbar meta instead of doing auth/data work during the public app-shell render
- simplify the hero/background motion stack and remove per-card pointer-tracking tilt work
- add small preview image loading tweaks for colder first visits

## Validation
- npm run lint
- npm test
- npm run build