### PR TITLE
Fix homepage counter formatting runtime error

### DIFF
--- a/src/components/home/animated-count.tsx
+++ b/src/components/home/animated-count.tsx
@@ -2,27 +2,32 @@
 
 import { animate, useInView, useMotionValue, useReducedMotion } from "framer-motion";
 import { useEffect, useRef, useState } from "react";
+import { formatPrice } from "@/lib/formatting";
 
 interface AnimatedCountProps {
   value: number;
   duration?: number;
-  formatter?: (value: number) => string;
+  variant?: "integer" | "currency";
 }
 
-function defaultFormatter(value: number): string {
+function formatAnimatedValue(value: number, variant: AnimatedCountProps["variant"]): string {
+  if (variant === "currency") {
+    return formatPrice(Math.round(value));
+  }
+
   return String(Math.round(value));
 }
 
 export function AnimatedCount({
   value,
   duration = 1.2,
-  formatter = defaultFormatter,
+  variant = "integer",
 }: AnimatedCountProps) {
   const reduceMotion = useReducedMotion();
   const ref = useRef<HTMLSpanElement | null>(null);
   const inView = useInView(ref, { once: true, amount: 0.6 });
   const motionValue = useMotionValue(reduceMotion ? value : 0);
-  const [displayValue, setDisplayValue] = useState(() => formatter(reduceMotion ? value : 0));
+  const [displayValue, setDisplayValue] = useState(() => formatAnimatedValue(reduceMotion ? value : 0, variant));
 
   useEffect(() => {
     if (reduceMotion || !inView) return;
@@ -31,15 +36,15 @@ export function AnimatedCount({
       duration,
       ease: [0.22, 1, 0.36, 1],
       onUpdate: (latest) => {
-        setDisplayValue(formatter(latest));
+        setDisplayValue(formatAnimatedValue(latest, variant));
       },
     });
 
     return () => controls.stop();
-  }, [duration, formatter, inView, motionValue, reduceMotion, value]);
+  }, [duration, inView, motionValue, reduceMotion, value, variant]);
 
   if (reduceMotion) {
-    return <span ref={ref}>{formatter(value)}</span>;
+    return <span ref={ref}>{formatAnimatedValue(value, variant)}</span>;
   }
 
   return <span ref={ref}>{displayValue}</span>;

--- a/src/components/home/hero-client.tsx
+++ b/src/components/home/hero-client.tsx
@@ -78,21 +78,21 @@ export function HeroClient({
               <div className="metric-panel rounded-2xl p-4">
                 <p className="eyebrow">Listings</p>
                 <p className="mt-3 text-3xl font-semibold text-white">
-                  <AnimatedCount value={listingsCount} formatter={(v) => String(Math.round(v))} />
+                  <AnimatedCount value={listingsCount} variant="integer" />
                 </p>
                 <p className="mt-1 text-sm text-slate-400">Active listings live now</p>
               </div>
               <div className="metric-panel rounded-2xl p-4">
                 <p className="eyebrow">Inventory</p>
                 <p className="mt-3 text-3xl font-semibold text-white">
-                  <AnimatedCount value={totalSalesValue} formatter={(v) => formatPrice(Math.round(v))} />
+                  <AnimatedCount value={totalSalesValue} variant="currency" />
                 </p>
                 <p className="mt-1 text-sm text-slate-400">Asking value on-market</p>
               </div>
               <div className="metric-panel rounded-2xl p-4">
                 <p className="eyebrow">Beta Tests</p>
                 <p className="mt-3 text-3xl font-semibold text-white">
-                  <AnimatedCount value={betaTestsCount} formatter={(v) => String(Math.round(v))} />
+                  <AnimatedCount value={betaTestsCount} variant="integer" />
                 </p>
                 <p className="mt-1 text-sm text-slate-400">Open programs recruiting testers</p>
               </div>


### PR DESCRIPTION
## Summary
- replace function props passed from the homepage server hero into the client counter component
- use serializable counter variants so the homepage no longer throws on production runtime

## Validation
- npm run lint
- npm run build